### PR TITLE
GD-15: Added reset for mock and spy

### DIFF
--- a/addons/gdUnit3/src/GdUnitMock.gd
+++ b/addons/gdUnit3/src/GdUnitMock.gd
@@ -25,3 +25,9 @@ static func verify(mock :Object, times):
 
 static func verify_no_interactions(mock :Object):
 	mock.__verify_no_interactions()
+
+static func reset(mock :Object) -> void:
+	if mock is GDScript and not mock.get_script().has_script_method("__reset"):
+		push_error("Error: You try to reset a non mocked object.")
+		return
+	mock.__reset()

--- a/addons/gdUnit3/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit3/src/GdUnitTestSuite.gd
@@ -101,8 +101,12 @@ func verify(obj, times := 1):
 	return GdUnitMock.verify(obj, times)
 
 # Verifies no interactions is happen on this mock or spy
-func verify_no_interactions(mock):
-	return GdUnitMock.verify_no_interactions(mock)
+func verify_no_interactions(obj):
+	return GdUnitMock.verify_no_interactions(obj)
+
+# Resets the saved function call counters on a mock or spy
+func reset(obj) -> void:
+	GdUnitMock.reset(obj)
 
 # === Argument matchers ========================================================
 # Argument matcher to match any argument

--- a/addons/gdUnit3/src/mocking/GdUnitMockImpl.gd
+++ b/addons/gdUnit3/src/mocking/GdUnitMockImpl.gd
@@ -36,6 +36,9 @@ func __save_function_call_times(args :Array):
 	var times :int = _saved_function_calls.get(args, 0)
 	_saved_function_calls[args] = times + 1
 
+func __reset() -> void:
+	_saved_function_calls.clear()
+
 func __is_verify() -> bool:
 	return _assert_function_call_times != -1
 

--- a/addons/gdUnit3/src/spy/GdUnitSpyImpl.gd
+++ b/addons/gdUnit3/src/spy/GdUnitSpyImpl.gd
@@ -25,6 +25,9 @@ func __release_double():
 func __save_function_call(args :Array):
 	_saved_function_calls[args] = _saved_function_calls.get(args, 0) + 1
 
+func __reset() -> void:
+	_saved_function_calls.clear()
+
 func __is_verify() -> bool:
 	return _assert_function_call_times != -1
 

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -545,3 +545,20 @@ func test_example_verify():
 
 	# verify total sum by using an argument matcher 
 	verify(mocked_node, 3).set_process(any_bool())
+
+func test_reset():
+	var instance :Node = auto_free(Node.new())
+	var mocked_node = mock(Node)
+	
+	# call with different arguments
+	mocked_node.set_process(false) # 1 times
+	mocked_node.set_process(true) # 1 times
+	mocked_node.set_process(true) # 2 times
+	
+	verify(mocked_node, 2).set_process(true)
+	verify(mocked_node, 1).set_process(false)
+	
+	# now reset the mock
+	reset(mocked_node)
+	# verify all counters are rested
+	verify_no_interactions(mocked_node)

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -560,5 +560,5 @@ func test_reset():
 	
 	# now reset the mock
 	reset(mocked_node)
-	# verify all counters are rested
+	# verify all counters have been reset
 	verify_no_interactions(mocked_node)

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -119,7 +119,7 @@ func test_reset():
 	
 	# now reset the spy
 	reset(spy_node)
-	# verify all counters are rested
+	# verify all counters have been reset
 	verify_no_interactions(spy_node)
 
 

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -101,11 +101,28 @@ func test_example_verify():
 	# verify how often we called the function with different argument 
 	verify(spy_node, 2).set_process(true) # in sum two times with true
 	verify(spy_node, 1).set_process(false)# in sum one time with false
-
+	
 	# verify total sum by using an argument matcher 
 	verify(spy_node, 3).set_process(any_bool())
+
+func test_reset():
+	var instance :Node = auto_free(Node.new())
+	var spy_node = spy(instance)
 	
+	# call with different arguments
+	spy_node.set_process(false) # 1 times
+	spy_node.set_process(true) # 1 times
+	spy_node.set_process(true) # 2 times
 	
+	verify(spy_node, 2).set_process(true)
+	verify(spy_node, 1).set_process(false)
+	
+	# now reset the spy
+	reset(spy_node)
+	# verify all counters are rested
+	verify_no_interactions(spy_node)
+
+
 class ClassWithStaticFunctions:
 	
 	static func foo() -> void:


### PR DESCRIPTION
- reset(<spy|mock>) allows now to reset the actual counted function calls for continues testing wiht the same spy or mock