### PR TITLE
GD-20: Refactore verify_no_interactions to return GdUnitAssert:

### DIFF
--- a/addons/gdUnit3/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit3/src/GdUnitTestSuite.gd
@@ -98,19 +98,19 @@ func do_return(value) -> GdUnitMock:
 
 # Verifies certain behavior happened at least once or exact number of times
 func verify(obj, times := 1):
-	return GdUnitMock.verify(obj, times)
+	return GdUnitObjectInteractions.verify(obj, times)
 
 # Verifies no interactions is happen on this mock or spy
 func verify_no_interactions(obj, expect_result :int = GdUnitAssert.EXPECT_SUCCESS) -> GdUnitAssert:
-	return GdUnitMock.verify_no_interactions(obj, expect_result)
+	return GdUnitObjectInteractions.verify_no_interactions(obj, expect_result)
 
 # Verifies the given mock or spy has any unverified interaction.
 func verify_no_more_interactions(obj, expect_result :int = GdUnitAssert.EXPECT_SUCCESS) -> GdUnitAssert:
-	return GdUnitMock.verify_no_more_interactions(obj, expect_result)
+	return GdUnitObjectInteractions.verify_no_more_interactions(obj, expect_result)
 
 # Resets the saved function call counters on a mock or spy
 func reset(obj) -> void:
-	GdUnitMock.reset(obj)
+	GdUnitObjectInteractions.reset(obj)
 
 # === Argument matchers ========================================================
 # Argument matcher to match any argument

--- a/addons/gdUnit3/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit3/src/GdUnitTestSuite.gd
@@ -97,8 +97,8 @@ func do_return(value) -> GdUnitMock:
 	return GdUnitMock.new(value)
 
 # Verifies certain behavior happened at least once or exact number of times
-func verify(obj, times := 1):
-	return GdUnitObjectInteractions.verify(obj, times)
+func verify(obj, times := 1, expect_result :int = GdUnitAssert.EXPECT_SUCCESS):
+	return GdUnitObjectInteractions.verify(obj, times, expect_result)
 
 # Verifies no interactions is happen on this mock or spy
 func verify_no_interactions(obj, expect_result :int = GdUnitAssert.EXPECT_SUCCESS) -> GdUnitAssert:

--- a/addons/gdUnit3/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit3/src/GdUnitTestSuite.gd
@@ -101,8 +101,8 @@ func verify(obj, times := 1):
 	return GdUnitMock.verify(obj, times)
 
 # Verifies no interactions is happen on this mock or spy
-func verify_no_interactions(obj):
-	return GdUnitMock.verify_no_interactions(obj)
+func verify_no_interactions(obj, expect_result :int = GdUnitAssert.EXPECT_SUCCESS) -> GdUnitAssert:
+	return GdUnitMock.verify_no_interactions(obj, expect_result)
 
 # Verifies the given mock or spy has any unverified interaction.
 func verify_no_more_interactions(obj, expect_result :int = GdUnitAssert.EXPECT_SUCCESS) -> GdUnitAssert:

--- a/addons/gdUnit3/src/asserts/GdAssertReports.gd
+++ b/addons/gdUnit3/src/asserts/GdAssertReports.gd
@@ -3,13 +3,14 @@ extends Reference
 
 
 # if a test success but we expect to fail map to an error
-static func report_success(gd_assert :GdUnitAssert) -> void:
+static func report_success(gd_assert :GdUnitAssert) -> GdUnitAssert:
 	if not gd_assert._expect_fail || gd_assert._is_failed:
-		return
-	send_report(GdAssertMessages._error("Expecting to fail!"), -1, GdUnitReport.SUCCESS)
+		return gd_assert
+	send_report(GdAssertMessages._error("Expecting to fail!"), gd_assert._get_line_number(), GdUnitReport.SUCCESS)
+	return gd_assert
 
 
-static func report_error(message:String, gd_assert :GdUnitAssert, line_number :int):
+static func report_error(message:String, gd_assert :GdUnitAssert, line_number :int) -> GdUnitAssert:
 	if gd_assert != null:
 		gd_assert._is_failed = true
 		gd_assert._current_error_message = message

--- a/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
@@ -31,8 +31,8 @@ func _init(current, expect_result :int = EXPECT_SUCCESS):
 	if expect_result == EXPECT_FAIL:
 		_expect_fail = true
 
-func report_success() -> void:
-	GdAssertReports.report_success(self)
+func report_success() -> GdUnitAssert:
+	return GdAssertReports.report_success(self)
 
 func report_error(error_message :String) -> GdUnitAssert:
 	var line_number := _get_line_number()

--- a/addons/gdUnit3/src/core/GdUnitClassDoubler.gd
+++ b/addons/gdUnit3/src/core/GdUnitClassDoubler.gd
@@ -30,12 +30,19 @@ static func extract_class_functions(clazz_name :String, script_path :PoolStringA
 # loads the doubler template
 static func load_template(template :Object, clazz :String) -> PoolStringArray:
 	var source_code = template.new().get_script().source_code
-	var lines := Array(GdScriptParser.to_unix_format(source_code).split("\n"))
+	var lines := GdScriptParser.to_unix_format(source_code).split("\n")
 	# replace template class_name with Doubled<class> name and extends form source class
 	lines.remove(2)
 	lines.insert(2, "class_name Doubled%s" % clazz.replace(".", "_"))
 	lines.insert(3, "extends %s" % clazz)
-	return PoolStringArray(lines)
+	
+	var eol := lines.size()
+	# append Object interactions stuff
+	source_code = GdUnitObjectInteractionsTemplate.new().get_script().source_code
+	lines += GdScriptParser.to_unix_format(source_code).split("\n")
+	# remove the class header from GdUnitObjectInteractionsTemplate
+	lines.remove(eol)
+	return lines
 
 # double all functions of given instance
 static func double_functions(clazz_name :String, clazz_path :PoolStringArray, func_doubler: GdFunctionDoubler) -> PoolStringArray:

--- a/addons/gdUnit3/src/core/GdUnitObjectInteractions.gd
+++ b/addons/gdUnit3/src/core/GdUnitObjectInteractions.gd
@@ -1,0 +1,37 @@
+class_name GdUnitObjectInteractions
+extends Reference
+
+static func verify(obj :Object, times):
+	if not _is_mock_or_spy( obj, "__verify"):
+		return obj
+	return obj.__do_verify_interactions(times)
+
+static func verify_no_interactions(obj :Object, expect_result :int) -> GdUnitAssert:
+	var gd_assert := GdUnitAssertImpl.new("", expect_result)
+	if not _is_mock_or_spy( obj, "__verify"):
+		return gd_assert.report_success()
+	var summary :Dictionary = obj.__verify_no_interactions()
+	if summary.empty():
+		return gd_assert.report_success()
+	return gd_assert.report_error(GdAssertMessages.error_no_more_interactions(summary))
+
+static func verify_no_more_interactions(obj :Object, expect_result :int) -> GdUnitAssert:
+	var gd_assert := GdUnitAssertImpl.new("", expect_result)
+	if not _is_mock_or_spy( obj, "__verify_no_more_interactions"):
+		return gd_assert
+	var summary :Dictionary = obj.__verify_no_more_interactions()
+	if summary.empty():
+		return gd_assert
+	return gd_assert.report_error(GdAssertMessages.error_no_more_interactions(summary))
+
+static func reset(obj :Object) -> Object:
+	if not _is_mock_or_spy( obj, "__reset"):
+		return obj
+	obj.__reset_interactions()
+	return obj
+
+static func _is_mock_or_spy(obj :Object, func_sig :String) -> bool:
+	if obj is GDScript and not obj.get_script().has_script_method(func_sig):
+		push_error("Error: You try to use a non mock or spy!")
+		return false
+	return true

--- a/addons/gdUnit3/src/core/GdUnitObjectInteractions.gd
+++ b/addons/gdUnit3/src/core/GdUnitObjectInteractions.gd
@@ -1,10 +1,10 @@
 class_name GdUnitObjectInteractions
 extends Reference
 
-static func verify(obj :Object, times):
+static func verify(obj :Object, times, expect_result :int):
 	if not _is_mock_or_spy( obj, "__verify"):
 		return obj
-	return obj.__do_verify_interactions(times)
+	return obj.__do_verify_interactions(times, expect_result)
 
 static func verify_no_interactions(obj :Object, expect_result :int) -> GdUnitAssert:
 	var gd_assert := GdUnitAssertImpl.new("", expect_result)

--- a/addons/gdUnit3/src/core/GdUnitObjectInteractionsTemplate.gd
+++ b/addons/gdUnit3/src/core/GdUnitObjectInteractionsTemplate.gd
@@ -1,0 +1,57 @@
+class_name GdUnitObjectInteractionsTemplate
+
+var __expected_interactions :int = -1
+var __saved_interactions := Dictionary()
+var __verified_interactions := Array()
+
+func __save_function_interaction(args :Array) -> void:
+	__saved_interactions[args] = __saved_interactions.get(args, 0) + 1
+
+func __is_verify_interactions() -> bool:
+	return __expected_interactions != -1
+
+func __do_verify_interactions(times :int = 1) -> Object:
+	__expected_interactions = times
+	return self
+
+func __verify_interactions(args :Array):
+	var summary := Dictionary()
+	var total_interactions := 0
+	var matcher := GdUnitArgumentMatchers.to_matcher(args)
+	for key in __saved_interactions.keys():
+		if matcher.is_match(key):
+			var interactions :int = __saved_interactions.get(key, 0)
+			total_interactions += interactions
+			summary[key] = interactions
+			# add as verified
+			__verified_interactions.append(key)
+	
+	var gd_assert := GdUnitAssertImpl.new("", GdUnitAssert.EXPECT_SUCCESS)
+	if summary.empty():
+		gd_assert.report_success()
+	elif total_interactions != __expected_interactions:
+		gd_assert.report_error(GdAssertMessages.error_no_more_interactions(summary))
+	__expected_interactions = -1
+
+func __verify_no_interactions() -> Dictionary:
+	var summary := Dictionary()
+	if not __saved_interactions.empty():
+		for func_call in __saved_interactions.keys():
+			summary[func_call] = __saved_interactions[func_call]
+	return summary
+
+func __verify_no_more_interactions() -> Dictionary:
+	var summary := Dictionary()
+	var called_functions :Array = __saved_interactions.keys()
+	if called_functions != __verified_interactions:
+		# collect the not verified functions
+		var called_but_not_verified := called_functions.duplicate()
+		for verified_function in __verified_interactions:
+			called_but_not_verified.erase(verified_function)
+		
+		for not_verified in called_but_not_verified:
+			summary[not_verified] = __saved_interactions[not_verified]
+	return summary
+
+func __reset_interactions() -> void:
+	__saved_interactions.clear()

--- a/addons/gdUnit3/src/core/GdUnitObjectInteractionsTemplate.gd
+++ b/addons/gdUnit3/src/core/GdUnitObjectInteractionsTemplate.gd
@@ -1,6 +1,7 @@
 class_name GdUnitObjectInteractionsTemplate
 
 var __expected_interactions :int = -1
+var __expect_result :int
 var __saved_interactions := Dictionary()
 var __verified_interactions := Array()
 
@@ -10,8 +11,9 @@ func __save_function_interaction(args :Array) -> void:
 func __is_verify_interactions() -> bool:
 	return __expected_interactions != -1
 
-func __do_verify_interactions(times :int = 1) -> Object:
+func __do_verify_interactions(times :int = 1, expect_result :int = GdUnitAssert.EXPECT_SUCCESS) -> Object:
 	__expected_interactions = times
+	__expect_result = expect_result
 	return self
 
 func __verify_interactions(args :Array):
@@ -26,7 +28,7 @@ func __verify_interactions(args :Array):
 			# add as verified
 			__verified_interactions.append(key)
 	
-	var gd_assert := GdUnitAssertImpl.new("", GdUnitAssert.EXPECT_SUCCESS)
+	var gd_assert := GdUnitAssertImpl.new("", __expect_result)
 	if summary.empty():
 		gd_assert.report_success()
 	elif total_interactions != __expected_interactions:

--- a/addons/gdUnit3/src/mocking/GdUnitMock.gd
+++ b/addons/gdUnit3/src/mocking/GdUnitMock.gd
@@ -24,11 +24,14 @@ static func verify(obj :Object, times):
 		return obj
 	return obj.__do_verify(times)
 
-static func verify_no_interactions(obj :Object) -> Object:
+static func verify_no_interactions(obj :Object, expect_result :int) -> GdUnitAssert:
+	var gd_assert := GdUnitAssertImpl.new("", expect_result)
 	if not _is_mock_or_spy( obj, "__verify"):
-		return obj
-	obj.__verify_no_interactions()
-	return obj
+		return gd_assert.report_success()
+	var summary :Dictionary = obj.__verify_no_interactions()
+	if summary.empty():
+		return gd_assert.report_success()
+	return gd_assert.report_error(GdAssertMessages.error_no_more_interactions(summary))
 
 static func verify_no_more_interactions(obj :Object, expect_result :int) -> GdUnitAssert:
 	var gd_assert := GdUnitAssertImpl.new("", expect_result)
@@ -37,8 +40,7 @@ static func verify_no_more_interactions(obj :Object, expect_result :int) -> GdUn
 	var summary :Dictionary = obj.__verify_no_more_interactions()
 	if summary.empty():
 		return gd_assert
-	gd_assert.report_error(GdAssertMessages.error_no_more_interactions(summary))
-	return gd_assert
+	return gd_assert.report_error(GdAssertMessages.error_no_more_interactions(summary))
 
 static func reset(obj :Object) -> Object:
 	if not _is_mock_or_spy( obj, "__reset"):

--- a/addons/gdUnit3/src/mocking/GdUnitMock.gd
+++ b/addons/gdUnit3/src/mocking/GdUnitMock.gd
@@ -19,36 +19,6 @@ func on(obj :Object):
 		return obj
 	return obj.__do_return(_value)
 
-static func verify(obj :Object, times):
-	if not _is_mock_or_spy( obj, "__verify"):
-		return obj
-	return obj.__do_verify(times)
-
-static func verify_no_interactions(obj :Object, expect_result :int) -> GdUnitAssert:
-	var gd_assert := GdUnitAssertImpl.new("", expect_result)
-	if not _is_mock_or_spy( obj, "__verify"):
-		return gd_assert.report_success()
-	var summary :Dictionary = obj.__verify_no_interactions()
-	if summary.empty():
-		return gd_assert.report_success()
-	return gd_assert.report_error(GdAssertMessages.error_no_more_interactions(summary))
-
-static func verify_no_more_interactions(obj :Object, expect_result :int) -> GdUnitAssert:
-	var gd_assert := GdUnitAssertImpl.new("", expect_result)
-	if not _is_mock_or_spy( obj, "__verify_no_more_interactions"):
-		return gd_assert
-	var summary :Dictionary = obj.__verify_no_more_interactions()
-	if summary.empty():
-		return gd_assert
-	return gd_assert.report_error(GdAssertMessages.error_no_more_interactions(summary))
-
-static func reset(obj :Object) -> Object:
-	if not _is_mock_or_spy( obj, "__reset"):
-		return obj
-	obj.__reset()
-	return obj
-
-
 static func _is_mock_or_spy(obj :Object, func_sig :String) -> bool:
 	if obj is GDScript and not obj.get_script().has_script_method(func_sig):
 		push_error("Error: You try to use a non mock or spy!")

--- a/addons/gdUnit3/src/mocking/GdUnitMockBuilder.gd
+++ b/addons/gdUnit3/src/mocking/GdUnitMockBuilder.gd
@@ -8,15 +8,16 @@ const MOCK_TEMPLATE =\
 	#prints("--->", args)
 	if $(instance)__is_prepare_return_value():
 		return $(instance)__save_function_return_value(args)
-	if $(instance)__is_verify():
-		return $(instance)__verify(args, ${default_return_value})
+	if $(instance)__is_verify_interactions():
+		$(instance)__verify_interactions(args)
+		return ${default_return_value}
 	else:
-		$(instance)__save_function_call_times(args)
+		$(instance)__save_function_interaction(args)
 
-	if $(instance)_saved_return_values.has(args):
-		return $(instance)_saved_return_values.get(args)
+	if $(instance)__saved_return_values.has(args):
+		return $(instance)__saved_return_values.get(args)
 
-	if $(instance)_working_mode == GdUnitMock.CALL_REAL_FUNC:
+	if $(instance)__working_mode == GdUnitMock.CALL_REAL_FUNC:
 		return .$(func_name)($(func_arg))
 	return ${default_return_value}
 """
@@ -29,13 +30,13 @@ const MOCK_VOID_TEMPLATE =\
 		if $(push_errors):
 			push_error(\"Mocking a void function '$(func_name)(<args>) -> void:' is not allowed.\")
 		return
-	if $(instance)__is_verify():
-		$(instance)__verify(args, null)
+	if $(instance)__is_verify_interactions():
+		$(instance)__verify_interactions(args)
 		return
 	else:
-		$(instance)__save_function_call_times(args)
+		$(instance)__save_function_interaction(args)
 	
-	if $(instance)_working_mode == GdUnitMock.CALL_REAL_FUNC:
+	if $(instance)__working_mode == GdUnitMock.CALL_REAL_FUNC:
 		.$(func_name)($(func_arg))
 """
 
@@ -69,7 +70,7 @@ class MockFunctionDoubler extends GdFunctionDoubler:
 			.replace("${default_return_value}", default_return_value)\
 			.replace("$(push_errors)", _push_errors)
 		if is_static:
-			double = double.replace("$(instance)", "_self[0].")
+			double = double.replace("$(instance)", "__self[0].")
 		else:
 			double = double.replace("$(instance)", "")
 		return double.split("\n")

--- a/addons/gdUnit3/src/mocking/GdUnitMockImpl.gd
+++ b/addons/gdUnit3/src/mocking/GdUnitMockImpl.gd
@@ -68,9 +68,12 @@ func __do_verify(times :int = 1):
 	_assert_function_call_times = times
 	return self
 
-func __verify_no_interactions():
+func __verify_no_interactions() -> Dictionary:
+	var summary := Dictionary()
 	if not _saved_function_calls.empty():
-		GdUnitArrayAssertImpl.new([], GdUnitAssert.EXPECT_SUCCESS).contains(_saved_function_calls.keys())
+		for func_call in _saved_function_calls.keys():
+			summary[func_call] = _saved_function_calls[func_call]
+	return summary
 
 func __verify_no_more_interactions() -> Dictionary:
 	var summary := Dictionary()

--- a/addons/gdUnit3/src/mocking/GdUnitMockImpl.gd
+++ b/addons/gdUnit3/src/mocking/GdUnitMockImpl.gd
@@ -5,85 +5,35 @@ class_name GdUnitMockImpl
 ################################################################################
 # internal mocking stuff
 ################################################################################
-var _working_mode :String
-var _assert_function_call_times :int = -1
-var _do_return_value = null
-var _saved_return_values := Dictionary()
-var _saved_function_calls := Dictionary()
-var _verified_functions := Array()
+var __working_mode :String
 
+var __do_return_value = null
+var __saved_return_values := Dictionary()
 
 # self reference holder, use this kind of hack to store static function calls 
 # it is important to manually free by '__release_double' otherwise it ends up in orphan instance
-const _self := []
+const __self := []
 
 func __set_singleton():
 	# store self need to mock static functions
-	_self.append(self)
+	__self.append(self)
 
 func __release_double():
 	# we need to release the self reference manually to prevent orphan nodes
-	_self.clear()
+	__self.clear()
 
 func __is_prepare_return_value() -> bool:
-	return _do_return_value != null
+	return __do_return_value != null
 
 func __save_function_return_value(args :Array):
-	_saved_return_values[args] = _do_return_value
-	_do_return_value = null
-	return _saved_return_values[args]
-
-func __save_function_call_times(args :Array):
-	var times :int = _saved_function_calls.get(args, 0)
-	_saved_function_calls[args] = times + 1
-
-func __reset() -> void:
-	_saved_function_calls.clear()
-
-func __is_verify() -> bool:
-	return _assert_function_call_times != -1
-
-func __verify(args :Array, default_return_value):
-	var times :int =  0
-	var matcher := GdUnitArgumentMatchers.to_matcher(args)
-	for key in _saved_function_calls.keys():
-		if matcher.is_match(key):
-			times += _saved_function_calls.get(key, 0)
-			# add as verified
-			_verified_functions.append(key)
-	
-	GdUnitIntAssertImpl.new(times, GdUnitAssert.EXPECT_SUCCESS).is_equal(_assert_function_call_times)
-	_assert_function_call_times = -1
-	return default_return_value
+	__saved_return_values[args] = __do_return_value
+	__do_return_value = null
+	return __saved_return_values[args]
 
 func __set_mode(mode :String):
-	_working_mode = mode
+	__working_mode = mode
 	return self
 
 func __do_return(value):
-	_do_return_value = value
+	__do_return_value = value
 	return self
-
-func __do_verify(times :int = 1):
-	_assert_function_call_times = times
-	return self
-
-func __verify_no_interactions() -> Dictionary:
-	var summary := Dictionary()
-	if not _saved_function_calls.empty():
-		for func_call in _saved_function_calls.keys():
-			summary[func_call] = _saved_function_calls[func_call]
-	return summary
-
-func __verify_no_more_interactions() -> Dictionary:
-	var summary := Dictionary()
-	var called_functions :Array = _saved_function_calls.keys()
-	if called_functions != _verified_functions:
-		# collect the not verified functions
-		var called_but_not_verified := called_functions.duplicate()
-		for verified_function in _verified_functions:
-			called_but_not_verified.erase(verified_function)
-		
-		for not_verified in called_but_not_verified:
-			summary[not_verified] = _saved_function_calls[not_verified]
-	return summary

--- a/addons/gdUnit3/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit3/src/spy/GdUnitSpyBuilder.gd
@@ -5,23 +5,23 @@ const SPY_TEMPLATE = \
 """	var args = $(args)
 	
 	#prints("--->", args)
-	if $(instance)__is_verify():
-		return $(instance)__verify(args)
+	if $(instance)__is_verify_interactions():
+		return $(instance)__verify_interactions(args)
 	else:
-		$(instance)__save_function_call(args)
-	return $(instance)_instance_delegator.$(func_name)($(func_arg))
+		$(instance)__save_function_interaction(args)
+	return $(instance)__instance_delegator.$(func_name)($(func_arg))
 """
 
 const SPY_VOID_TEMPLATE = \
 """	var args = $(args)
 	
 	#prints("--->", args)
-	if $(instance)__is_verify():
-		$(instance)__verify(args)
+	if $(instance)__is_verify_interactions():
+		$(instance)__verify_interactions(args)
 		return
 	else:
-		$(instance)__save_function_call(args)
-	$(instance)_instance_delegator.$(func_name)($(func_arg))
+		$(instance)__save_function_interaction(args)
+	$(instance)__instance_delegator.$(func_name)($(func_arg))
 """
 
 class SpyFunctionDoubler extends GdFunctionDoubler:
@@ -49,7 +49,7 @@ class SpyFunctionDoubler extends GdFunctionDoubler:
 			.replace("$(func_name)", func_name )\
 			.replace("$(func_arg)", arg_names.join(","))
 		if is_static:
-			double = double.replace("$(instance)", "_self[0].")
+			double = double.replace("$(instance)", "__self[0].")
 		else:
 			double = double.replace("$(instance)", "")
 		return double.split("\n")

--- a/addons/gdUnit3/src/spy/GdUnitSpyImpl.gd
+++ b/addons/gdUnit3/src/spy/GdUnitSpyImpl.gd
@@ -49,8 +49,11 @@ func __do_verify(times :int = 1):
 	return self 
 
 func __verify_no_interactions():
+	var summary := Dictionary()
 	if not _saved_function_calls.empty():
-		GdUnitArrayAssertImpl.new([], GdUnitAssert.EXPECT_SUCCESS).contains(_saved_function_calls.keys())
+		for func_call in _saved_function_calls.keys():
+			summary[func_call] = _saved_function_calls[func_call]
+	return summary
 
 func __verify_no_more_interactions() -> Dictionary:
 	var summary := Dictionary()

--- a/addons/gdUnit3/src/spy/GdUnitSpyImpl.gd
+++ b/addons/gdUnit3/src/spy/GdUnitSpyImpl.gd
@@ -2,68 +2,19 @@
 # warning-ignore:unused_argument
 class_name GdUnitSpyImpl
 
-
-var _instance_delegator
-var _assert_function_call_times :int = -1
-var _saved_function_calls = Dictionary()
-var _verified_functions := Array()
-
+var __instance_delegator
 
 # self reference holder, use this kind of hack to store static function calls 
 # it is important to manually free by '__release_double' otherwise it ends up in orphan instance
-const _self := []
+const __self := []
 
 func __set_singleton(instance):
 	# store self need to mock static functions
-	_self.append(self)
-	_instance_delegator = instance
+	__self.append(self)
+	__instance_delegator = instance
 
 func __release_double():
 	# we need to release the self reference manually to prevent orphan nodes
-	_self.clear()
-	_instance_delegator = null
+	__self.clear()
+	__instance_delegator = null
 
-func __save_function_call(args :Array):
-	_saved_function_calls[args] = _saved_function_calls.get(args, 0) + 1
-
-func __reset() -> void:
-	_saved_function_calls.clear()
-
-func __is_verify() -> bool:
-	return _assert_function_call_times != -1
-
-func __verify(args :Array):
-	var times :int =  0
-	var matcher := GdUnitArgumentMatchers.to_matcher(args)
-	for key in _saved_function_calls.keys():
-		if matcher.is_match(key):
-			times += _saved_function_calls.get(key, 0)
-			# add as verified
-			_verified_functions.append(key)
-
-	GdUnitIntAssertImpl.new(times, GdUnitAssert.EXPECT_SUCCESS).is_equal(_assert_function_call_times)
-	_assert_function_call_times = -1
-
-func __do_verify(times :int = 1):
-	_assert_function_call_times = times
-	return self 
-
-func __verify_no_interactions():
-	var summary := Dictionary()
-	if not _saved_function_calls.empty():
-		for func_call in _saved_function_calls.keys():
-			summary[func_call] = _saved_function_calls[func_call]
-	return summary
-
-func __verify_no_more_interactions() -> Dictionary:
-	var summary := Dictionary()
-	var called_functions :Array = _saved_function_calls.keys()
-	if called_functions != _verified_functions:
-		# collect the not verified functions
-		var called_but_not_verified := called_functions.duplicate()
-		for verified_function in _verified_functions:
-			called_but_not_verified.erase(verified_function)
-		
-		for not_verified in called_but_not_verified:
-			summary[not_verified] = _saved_function_calls[not_verified]
-	return summary

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -546,6 +546,19 @@ func test_example_verify():
 	# verify total sum by using an argument matcher 
 	verify(mocked_node, 3).set_process(any_bool())
 
+func test_verify_fail():
+	var mocked_node :Node = mock(Node)
+	
+	# interact two time
+	mocked_node.set_process(true) # 1 times
+	mocked_node.set_process(true) # 2 times
+	
+	# verify we interacts two times
+	verify(mocked_node, 2).set_process(true)
+	
+	# verify should fail because we interacts two times and not one
+	verify(mocked_node, 1, GdUnitAssert.EXPECT_FAIL).set_process(true)
+
 func test_reset():
 	var mocked_node = mock(Node)
 	

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -562,6 +562,28 @@ func test_reset():
 	# verify all counters have been reset
 	verify_no_interactions(mocked_node)
 
+func test_verify_no_interactions():
+	var mocked_node = mock(Node)
+	
+	# verify we have no interactions on this mock
+	verify_no_interactions(mocked_node)
+
+func test_verify_no_interactions_fails():
+	var mocked_node = mock(Node)
+	
+	# interact
+	mocked_node.set_process(false) # 1 times
+	mocked_node.set_process(true) # 1 times
+	mocked_node.set_process(true) # 2 times
+	
+	var expected_error ="""Expecting no more interacions!
+But found interactions on:
+	'set_process(False)'	1 time's
+	'set_process(True)'	2 time's"""
+	# it should fail because we have interactions 
+	verify_no_interactions(mocked_node, GdUnitAssert.EXPECT_FAIL)\
+		.has_error_message(expected_error)
+
 func test_verify_no_more_interactions():
 	var mocked_node :Node = mock(Node)
 	

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -105,6 +105,20 @@ func test_example_verify():
 	# verify total sum by using an argument matcher 
 	verify(spy_node, 3).set_process(any_bool())
 
+func test_verify_fail():
+	var instance :Node = auto_free(Node.new())
+	var spy_node = spy(instance)
+	
+	# interact two time
+	spy_node.set_process(true) # 1 times
+	spy_node.set_process(true) # 2 times
+	
+	# verify we interacts two times
+	verify(spy_node, 2).set_process(true)
+	
+	# verify should fail because we interacts two times and not one
+	verify(spy_node, 1, GdUnitAssert.EXPECT_FAIL).set_process(true)
+
 func test_reset():
 	var instance :Node = auto_free(Node.new())
 	var spy_node = spy(instance)

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -122,6 +122,30 @@ func test_reset():
 	# verify all counters have been reset
 	verify_no_interactions(spy_node)
 
+func test_verify_no_interactions():
+	var instance :Node = auto_free(Node.new())
+	var spy_node = spy(instance)
+	
+	# verify we have no interactions on this mock
+	verify_no_interactions(spy_node)
+
+func test_verify_no_interactions_fails():
+	var instance :Node = auto_free(Node.new())
+	var spy_node = spy(instance)
+	
+	# interact
+	spy_node.set_process(false) # 1 times
+	spy_node.set_process(true) # 1 times
+	spy_node.set_process(true) # 2 times
+	
+	var expected_error ="""Expecting no more interacions!
+But found interactions on:
+	'set_process(False)'	1 time's
+	'set_process(True)'	2 time's"""
+	# it should fail because we have interactions 
+	verify_no_interactions(spy_node, GdUnitAssert.EXPECT_FAIL)\
+		.has_error_message(expected_error)
+
 func test_verify_no_more_interactions():
 	var instance :Node = auto_free(Node.new())
 	var spy_node :Node = spy(instance)

--- a/project.godot
+++ b/project.godot
@@ -404,6 +404,16 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gdUnit3/test/asserts/GdUnitObjectAssertImplTest.gd"
 }, {
+"base": "Reference",
+"class": "GdUnitObjectInteractions",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/src/core/GdUnitObjectInteractions.gd"
+}, {
+"base": "Reference",
+"class": "GdUnitObjectInteractionsTemplate",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/src/core/GdUnitObjectInteractionsTemplate.gd"
+}, {
 "base": "Node",
 "class": "GdUnitPushErrorHandler",
 "language": "GDScript",
@@ -664,6 +674,8 @@ _global_script_class_icons={
 "GdUnitObjectAssert": "",
 "GdUnitObjectAssertImpl": "",
 "GdUnitObjectAssertImplTest": "",
+"GdUnitObjectInteractions": "",
+"GdUnitObjectInteractionsTemplate": "",
 "GdUnitPushErrorHandler": "",
 "GdUnitReport": "",
 "GdUnitResultAssert": "",


### PR DESCRIPTION
- verify_no_interactions returns now the used GdUnitAssert instance for better test coverage
- added test coverage for verify_no_interactions
- fix small bug in asssertion expect to fail, fix error line reporting
- improve the error message for verify_no_interactions, now lists unexpected interactions