### PR TITLE
GD-28: Add support to run GdUnit in multipe Godot instances concurent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ mono_crash.*.json
 *~
 
 # temporary generated files
-addons/gdUnit3/GdUnitRunner.cfg
+GdUnitRunner.cfg

--- a/addons/gdUnit3/src/core/GdUnitRunner.gd
+++ b/addons/gdUnit3/src/core/GdUnitRunner.gd
@@ -23,7 +23,7 @@ var _signal_handler :SignalHandler
 var _result :Result
 
 func _init():
-		# minimize scene window on debug mode
+	# minimize scene window on debug mode
 	if OS.get_cmdline_args().size() == 1:
 		OS.set_window_title("GdUnit3 Runner (Debug)")
 		OS.set_window_minimized(true)

--- a/addons/gdUnit3/src/core/GdUnitRunnerConfig.gd
+++ b/addons/gdUnit3/src/core/GdUnitRunnerConfig.gd
@@ -1,26 +1,90 @@
 class_name GdUnitRunnerConfig
 extends Resource
 
+const INCLUDED = "included"
+const EXCLUDED = "ignored"
+const SERVER_PORT = "server_port"
+const EXIT_FAIL_FAST ="exit_on_first_fail"
+const CONFIG_FILE = "res://GdUnitRunner.cfg"
 
-# defines is the runner started in debug mode or not, true, false
-const DEBUG_MODE = "debug_mode"
-const SELECTED_TEST_SUITE_RESOURCES = "test_suites"
-const SELECTED_TEST_CASE = "test_case"
-const CONFIG_FILE = "res://addons/gdUnit3/GdUnitRunner.cfg"
+var _config := {
+		# a set of directories or testsuite paths as key and a optional set of testcases as values
+		INCLUDED :  Dictionary(),
+		# a set of excluded directories or testsuite paths
+		EXCLUDED : Dictionary(),
+		# the port of running test server for this session
+		SERVER_PORT : -1
+	}
 
-static func save_config(config:Dictionary) -> void:
+func clear() -> GdUnitRunnerConfig:
+	_config[INCLUDED] = Dictionary()
+	_config[EXCLUDED] = Dictionary()
+	return self
+
+func set_server_port(port :int) -> GdUnitRunnerConfig:
+	_config[SERVER_PORT] = port
+	return self
+
+func server_port() -> int:
+	return _config.get(SERVER_PORT, -1)
+
+func self_test() -> GdUnitRunnerConfig:
+	add_test_suite("res://addons/gdUnit3/test/")
+	return self
+
+func add_test_suite(resource_path :String) -> GdUnitRunnerConfig:
+	var to_execute := to_execute()
+	to_execute[resource_path] = to_execute.get(resource_path, Array())
+	return self
+
+func add_test_suites(resource_paths :PoolStringArray) -> GdUnitRunnerConfig:
+	for resource_path in resource_paths:
+		add_test_suite(resource_path)
+	return self
+
+func add_test_case(resource_path :String, test_name :String) -> GdUnitRunnerConfig:
+	var to_execute := to_execute()
+	var test_cases :Array = to_execute.get(resource_path, Array())
+	test_cases.append(test_name)
+	to_execute[resource_path] = test_cases
+	return self
+
+func ignore_test_suite(resource_path :String) -> GdUnitRunnerConfig:
+	to_ignore()[resource_path] = Array()
+	return self
+
+func ignore_test_case(resource_path :String, test_name :String) -> GdUnitRunnerConfig:
+	var to_ignore := to_ignore()
+	var test_cases :Array = to_ignore.get(resource_path, Array())
+	test_cases.append(test_name)
+	to_ignore[resource_path] = test_cases
+	return self
+
+func to_execute() -> Dictionary:
+	return _config.get(INCLUDED, {"res://" : []})
+
+func to_ignore() -> Dictionary:
+	return _config.get(EXCLUDED, [])
+
+func save(path :String = CONFIG_FILE) -> Result:
 	var file := File.new()
-	file.open(CONFIG_FILE, File.WRITE)
-	file.store_var(config)
-	file.close()
-	
-static func load_config() -> Dictionary:
-	var file := File.new()
-	var err := file.open(CONFIG_FILE, File.READ)
+	var err := file.open(path, File.WRITE)
 	if err != OK:
-		push_error("Can't find test runner config! Please select a test to run.")
-		return Dictionary()
-	var config := file.get_var() as Dictionary
+		return Result.error("Can't write test runner configuration '%s'! %s" % [path, GdUnitTools.error_as_string(err)])
+	file.store_var(_config)
 	file.close()
-	return config
+	return Result.success(path)
 
+func load(path :String = CONFIG_FILE) -> Result:
+	var file := File.new()
+	var err := file.open(path, File.READ)
+	match err:
+		OK:
+			pass
+		ERR_FILE_NOT_FOUND:
+			return Result.error("Can't find test runner configuration '%s'! Please select a test to run." % path)
+		_:
+			return Result.error("Can't load test runner configuration '%s'! ERROR: %s." % [path, GdUnitTools.error_as_string(err)])
+	_config = file.get_var() as Dictionary
+	file.close()
+	return Result.success(path)

--- a/addons/gdUnit3/src/network/GdUnitServer.gd
+++ b/addons/gdUnit3/src/network/GdUnitServer.gd
@@ -10,7 +10,13 @@ var _tasks := Dictionary()
 
 func _ready():
 	_signal_handler = GdUnitSingleton.get_or_create_singleton(SignalHandler.SINGLETON_NAME, "res://addons/gdUnit3/src/core/event/SignalHandler.gd")
-	_server.start_server()
+	var result := _server.start_server()
+	if result.is_error():
+		push_error(result.error_message())
+		return
+	var server_port :int = result.value()
+	Engine.set_meta("gdunit_server_port", server_port)
+	
 	_server.connect("client_connected", self, "_on_client_connected")
 	_server.connect("client_disconnected", self, "_on_client_disconnected")
 	_server.connect("server_message", self, "_on_server_message")

--- a/addons/gdUnit3/src/network/Network.gd
+++ b/addons/gdUnit3/src/network/Network.gd
@@ -52,8 +52,6 @@ func connect_client(port :int) -> Result:
 	prints("GdUnit3: Connect to test server 127.0.0.1:%d" % port)
 	var err :=  _peer.create_client("127.0.0.1", port)
 	if err != OK:
-		if err == ERR_ALREADY_IN_USE:
-			return Result.error("GdUnit3: Can't establish client, error code: %s" % err)
 		return Result.error("GdUnit3: Can't establish client, error code: %s" % err)
 	get_tree().set_network_peer(_peer)
 	return Result.success("GdUnit3: Client connected on port %d" % port)

--- a/addons/gdUnit3/src/network/Network.gd
+++ b/addons/gdUnit3/src/network/Network.gd
@@ -40,7 +40,7 @@ func start_server() -> Result:
 			return Result.error("GdUnit3: Can't establish server, error code: %s, The server is already in use" % err)
 		return Result.error("GdUnit3: Can't establish server, error code: %s" % err)
 	get_tree().set_network_peer(_peer)
-	print_debug("GdUnit3: Server successfully started on port %d" % server_port)
+	prints("GdUnit3: Server successfully started on port %d" % server_port)
 	return Result.success(server_port)
 
 func connect_client(port :int) -> Result:
@@ -49,11 +49,12 @@ func connect_client(port :int) -> Result:
 	_peer.connect("connection_failed", self, "_on_connection_failed")
 	_peer.allow_object_decoding = true
 
+	prints("GdUnit3: Connect to test server 127.0.0.1:%d" % port)
 	var err :=  _peer.create_client("127.0.0.1", port)
 	if err != OK:
 		if err == ERR_ALREADY_IN_USE:
-			return Result.error("GdUnit3: Can't establish server, error code: %s, The server is already in use" % err)
-		return Result.error("GdUnit3: Can't establish server, error code: %s" % err)
+			return Result.error("GdUnit3: Can't establish client, error code: %s" % err)
+		return Result.error("GdUnit3: Can't establish client, error code: %s" % err)
 	get_tree().set_network_peer(_peer)
 	return Result.success("GdUnit3: Client connected on port %d" % port)
 

--- a/addons/gdUnit3/test/core/GdUnitRunnerConfigTest.gd
+++ b/addons/gdUnit3/test/core/GdUnitRunnerConfigTest.gd
@@ -1,0 +1,156 @@
+# GdUnit generated TestSuite
+class_name GdUnitRunnerConfigTest
+extends GdUnitTestSuite
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit3/src/core/GdUnitRunnerConfig.gd'
+
+func test_initial_config():
+	var config := GdUnitRunnerConfig.new()
+	assert_dict(config._config[GdUnitRunnerConfig.INCLUDED]).is_empty()
+	assert_dict(config._config[GdUnitRunnerConfig.EXCLUDED]).is_empty()
+
+func test_clear_on_initial_config():
+	var config := GdUnitRunnerConfig.new()
+	config.clear()
+	assert_dict(config._config[GdUnitRunnerConfig.INCLUDED]).is_empty()
+	assert_dict(config._config[GdUnitRunnerConfig.EXCLUDED]).is_empty()
+
+func test_clear_on_filled_config():
+	var config := GdUnitRunnerConfig.new()
+	config.add_test_suite("res://foo")
+	config.ignore_test_suite("res://bar")
+	assert_dict(config._config[GdUnitRunnerConfig.INCLUDED]).is_not_empty()
+	assert_dict(config._config[GdUnitRunnerConfig.EXCLUDED]).is_not_empty()
+	
+	# clear it
+	config.clear()
+	assert_dict(config._config[GdUnitRunnerConfig.INCLUDED]).is_empty()
+	assert_dict(config._config[GdUnitRunnerConfig.EXCLUDED]).is_empty()
+
+func test_set_server_port():
+	var config := GdUnitRunnerConfig.new()
+	# intial value
+	assert_int(config.server_port()).is_equal(-1)
+	
+	config.set_server_port(1000)
+	assert_int(config.server_port()).is_equal(1000)
+
+func test_self_test():
+	var config := GdUnitRunnerConfig.new()
+	# initial is empty
+	assert_dict(config.to_execute()).is_empty()
+	
+	# configure self test
+	var to_execute := config.self_test().to_execute()
+	assert_dict(to_execute).contains_key_value("res://addons/gdUnit3/test/", [])
+
+func test_add_test_suite():
+	var config := GdUnitRunnerConfig.new()
+	# ignore should have no affect
+	config.ignore_test_suite("res://bar")
+	
+	config.add_test_suite("res://foo")
+	assert_dict(config.to_execute()).contains_key_value("res://foo", [])
+	# add two more
+	config.add_test_suite("res://foo2")
+	config.add_test_suite("res://bar/foo")
+	assert_dict(config.to_execute())\
+		.contains_key_value("res://foo", [])\
+		.contains_key_value("res://foo2", [])\
+		.contains_key_value("res://bar/foo", [])\
+
+func test_add_test_suites():
+	var config := GdUnitRunnerConfig.new()
+	# ignore should have no affect
+	config.ignore_test_suite("res://bar")
+	
+	config.add_test_suites(PoolStringArray(["res://foo2", "res://bar/foo", "res://foo1"]))
+	
+	assert_dict(config.to_execute())\
+		.contains_key_value("res://foo1", [])\
+		.contains_key_value("res://foo2", [])\
+		.contains_key_value("res://bar/foo", [])\
+
+func test_add_test_case():
+	var config := GdUnitRunnerConfig.new()
+	# ignore should have no affect
+	config.ignore_test_suite("res://bar")
+	
+	config.add_test_case("res://foo1", "testcaseA")
+	assert_dict(config.to_execute()).contains_key_value("res://foo1", ["testcaseA"])
+	# add two more
+	config.add_test_case("res://foo1", "testcaseB")
+	config.add_test_case("res://foo2", "testcaseX")
+	assert_dict(config.to_execute())\
+		.contains_key_value("res://foo1", ["testcaseA", "testcaseB"])\
+		.contains_key_value("res://foo2", ["testcaseX"])
+
+func test_add_test_suites_and_test_cases_combi():
+	var config := GdUnitRunnerConfig.new()
+	
+	config.add_test_suite("res://foo1")
+	config.add_test_suite("res://foo2")
+	config.add_test_suite("res://bar/foo")
+	config.add_test_case("res://foo1", "testcaseA")
+	config.add_test_case("res://foo1", "testcaseB")
+	config.add_test_suites(PoolStringArray(["res://foo3", "res://bar/foo3", "res://foo4"]))
+	
+	assert_dict(config.to_execute())\
+		.has_size(6)\
+		.contains_key_value("res://foo1", ["testcaseA", "testcaseB"])\
+		.contains_key_value("res://foo2", [])\
+		.contains_key_value("res://foo3", [])\
+		.contains_key_value("res://foo4", [])\
+		.contains_key_value("res://bar/foo3", [])\
+		.contains_key_value("res://bar/foo", [])
+
+func test_ignore_test_suite():
+	var config := GdUnitRunnerConfig.new()
+	
+	config.ignore_test_suite("res://foo1")
+	assert_dict(config.to_ignore()).contains_key_value("res://foo1", [])
+	# add two more
+	config.ignore_test_suite("res://foo2")
+	config.ignore_test_suite("res://bar/foo1")
+	assert_dict(config.to_ignore())\
+		.contains_key_value("res://foo1", [])\
+		.contains_key_value("res://foo2", [])\
+		.contains_key_value("res://bar/foo1", [])
+
+func test_ignore_test_case():
+	var config := GdUnitRunnerConfig.new()
+	
+	config.ignore_test_case("res://foo1", "testcaseA")
+	assert_dict(config.to_ignore()).contains_key_value("res://foo1", ["testcaseA"])
+	# add two more
+	config.ignore_test_case("res://foo1", "testcaseB")
+	config.ignore_test_case("res://foo2", "testcaseX")
+	assert_dict(config.to_ignore())\
+		.contains_key_value("res://foo1", ["testcaseA", "testcaseB"])\
+		.contains_key_value("res://foo2", ["testcaseX"])
+
+func test_load_fail():
+	var config := GdUnitRunnerConfig.new()
+	
+	assert_result(config.load("invalid_path"))\
+		.is_error()\
+		.contains_message("Can't find test runner configuration 'invalid_path'! Please select a test to run.")
+
+func test_save_load():
+	var config := GdUnitRunnerConfig.new()
+	# add some dummy conf
+	config.set_server_port(1000)
+	config.ignore_test_suite("res://bar")
+	config.add_test_suite("res://foo2")
+	config.add_test_case("res://foo1", "testcaseA")
+	
+	var config_file := create_temp_dir("test_save_load") + "/testconf.cfg"
+
+	assert_result(config.save(config_file)).is_success()
+	assert_file(config_file).exists()
+	
+	var config2 := GdUnitRunnerConfig.new()
+	assert_result(config2.load(config_file)).is_success()
+	# verify the config has original enties
+	assert_object(config2).is_equal(config).is_not_same(config)

--- a/project.godot
+++ b/project.godot
@@ -449,6 +449,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gdUnit3/src/core/GdUnitRunnerConfig.gd"
 }, {
+"base": "GdUnitTestSuite",
+"class": "GdUnitRunnerConfigTest",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/test/core/GdUnitRunnerConfigTest.gd"
+}, {
 "base": "Reference",
 "class": "GdUnitSettings",
 "language": "GDScript",
@@ -688,6 +693,7 @@ _global_script_class_icons={
 "GdUnitResultAssertImpl": "",
 "GdUnitResultAssertImplTest": "",
 "GdUnitRunnerConfig": "",
+"GdUnitRunnerConfigTest": "",
 "GdUnitSettings": "",
 "GdUnitSingleton": "",
 "GdUnitSpyBuilder": "",


### PR DESCRIPTION

- comple rewrite GdUnitRunnerConfig and add test coverage
- the runner config is now stored in the project directory
- test server uses now retry to start to find next free port