### PR TITLE
GD-26: Generate static typed GDScript tests

### DIFF
--- a/addons/gdUnit3/src/core/_TestSuiteScanner.gd
+++ b/addons/gdUnit3/src/core/_TestSuiteScanner.gd
@@ -185,7 +185,7 @@ static func add_test_case(resource_path :String, func_name :String)  -> Result:
 	var script := load(resource_path) as GDScript
 	script.source_code +=\
 """
-func test_${func_name}():
+func test_${func_name}() -> void:
 	# remove this line and complete your test
 	assert_not_yet_implemented()
 """.replace("${func_name}", func_name)

--- a/addons/gdUnit3/test/core/TestSuiteScannerTest.gd
+++ b/addons/gdUnit3/test/core/TestSuiteScannerTest.gd
@@ -79,7 +79,7 @@ func test_create_test_case():
 			"# TestSuite generated from",
 			"const __source = '%s'" % source_path,
 			"",
-			"func test_last_name():",
+			"func test_last_name() -> void:",
 			"	# remove this line and complete your test",
 			"	assert_not_yet_implemented()",
 			""])


### PR DESCRIPTION
- added '-> void:' to generated tests to be conform with static typed GDScript