### PR TITLE
GD-27: Fix 'Run Tests' without debug mode shows no errors

### DIFF
--- a/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
@@ -11,7 +11,7 @@ var _error_info = null
 # Scans the current stack trace for the root cause to extract the line number
 static func _get_line_number() -> int:
 	var stack_trace := get_stack()
-	if stack_trace == null:
+	if stack_trace == null or stack_trace.empty():
 		return -1
 	
 	var failure_line := -1


### PR DESCRIPTION
- root cause was, on debug mode no stack trace is available and the 'get_stack()' will rsturn an empty array