### PR TITLE
GD-32: Fix mock and spy on class with snake case names.

### DIFF
--- a/addons/gdUnit3/src/core/GdUnitClassDoubler.gd
+++ b/addons/gdUnit3/src/core/GdUnitClassDoubler.gd
@@ -28,13 +28,13 @@ static func extract_class_functions(clazz_name :String, script_path :PoolStringA
 	return clazz_functions
 
 # loads the doubler template
-static func load_template(template :Object, clazz :String) -> PoolStringArray:
+static func load_template(template :Object, clazz_name :String, clazz_path :PoolStringArray) -> PoolStringArray:
 	var source_code = template.new().get_script().source_code
 	var lines := GdScriptParser.to_unix_format(source_code).split("\n")
 	# replace template class_name with Doubled<class> name and extends form source class
 	lines.remove(2)
-	lines.insert(2, "class_name Doubled%s" % clazz.replace(".", "_"))
-	lines.insert(3, "extends %s" % clazz)
+	lines.insert(2, "class_name Doubled%s" % clazz_name.replace(".", "_"))
+	lines.insert(3, "extends %s" % get_extends_clazz(clazz_name, clazz_path))
 	
 	var eol := lines.size()
 	# append Object interactions stuff
@@ -43,6 +43,12 @@ static func load_template(template :Object, clazz :String) -> PoolStringArray:
 	# remove the class header from GdUnitObjectInteractionsTemplate
 	lines.remove(eol)
 	return lines
+
+static func get_extends_clazz(clazz_name :String, clazz_path :PoolStringArray) -> String:
+	# handle snake_case class names, onyl if clazz path available and is an GdScript
+	if "_" in clazz_name and not clazz_path.empty() and (clazz_path[0].find(".gd") != -1):
+		return "'%s'" % clazz_path[0]
+	return clazz_name
 
 # double all functions of given instance
 static func double_functions(clazz_name :String, clazz_path :PoolStringArray, func_doubler: GdFunctionDoubler) -> PoolStringArray:

--- a/addons/gdUnit3/src/core/GdUnitClassDoubler.gd
+++ b/addons/gdUnit3/src/core/GdUnitClassDoubler.gd
@@ -45,7 +45,7 @@ static func load_template(template :Object, clazz_name :String, clazz_path :Pool
 	return lines
 
 static func get_extends_clazz(clazz_name :String, clazz_path :PoolStringArray) -> String:
-	# handle snake_case class names, onyl if clazz path available and is an GdScript
+	# handle snake_case class names, only if clazz path available and is a GdScript
 	if "_" in clazz_name and not clazz_path.empty() and (clazz_path[0].find(".gd") != -1):
 		return "'%s'" % clazz_path[0]
 	return clazz_name

--- a/addons/gdUnit3/src/mocking/GdUnitMockBuilder.gd
+++ b/addons/gdUnit3/src/mocking/GdUnitMockBuilder.gd
@@ -105,7 +105,7 @@ static func build(clazz, mock_mode :String, memory_pool :int, debug_write = fals
 		clazz_name = GdObjects.extract_class_name_from_class_path(clazz_path)
 	
 	var function_doubler := MockFunctionDoubler.new(push_errors)
-	var lines := load_template(GdUnitMockImpl, clazz_name)
+	var lines := load_template(GdUnitMockImpl, clazz_name, clazz_path)
 	lines += double_functions(clazz_name, clazz_path, function_doubler)
 	
 	var mock := GDScript.new()

--- a/addons/gdUnit3/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit3/src/spy/GdUnitSpyBuilder.gd
@@ -75,8 +75,8 @@ static func build(instance, memory_pool :int, push_errors :bool = true, debug_wr
 		push_error("Can't build spy for class type '%s'! Using an instance instead e.g. 'spy(<instance>)'" % [extends_clazz])
 		return null
 	
-	var lines := load_template(GdUnitSpyImpl, extends_clazz)
 	var clazz_path := GdObjects.extract_class_path(instance)
+	var lines := load_template(GdUnitSpyImpl, extends_clazz, clazz_path)
 	lines += double_functions(extends_clazz, clazz_path, SpyFunctionDoubler.new())
 
 	var spy := GDScript.new()

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -690,3 +690,47 @@ But found interactions on:
 	'find_node(mask :String, False :bool, False :bool)'	1 time's"""
 	verify_no_more_interactions(mocked_node, GdUnitAssert.EXPECT_FAIL)\
 		.has_error_message(expected_error)
+
+func test_mock_snake_case_named_class_by_resource_path():
+	var mock_a = mock("res://addons/gdUnit3/test/mocker/resources/snake_case.gd")
+	assert_object(mock_a).is_not_null()
+	
+	mock_a._ready()
+	verify(mock_a)._ready()
+	verify_no_more_interactions(mock_a)
+	
+	var mock_b = mock("res://addons/gdUnit3/test/mocker/resources/snake_case_class_name.gd")
+	assert_object(mock_b).is_not_null()
+	
+	mock_b._ready()
+	verify(mock_b)._ready()
+	verify_no_more_interactions(mock_b)
+	
+func test_mock_snake_case_named_godot_class_by_name():
+		# try on Godot class
+	var mocked_tcp_server :TCP_Server = mock("TCP_Server")
+	assert_object(mocked_tcp_server).is_not_null()
+	
+	mocked_tcp_server.is_listening()
+	mocked_tcp_server.is_connection_available()
+	verify(mocked_tcp_server).is_listening()
+	verify(mocked_tcp_server).is_connection_available()
+	verify_no_more_interactions(mocked_tcp_server)
+
+func test_mock_snake_case_named_class_by_class():
+	var mock = mock(snake_case_class_name)
+	assert_object(mock).is_not_null()
+	
+	mock._ready()
+	verify(mock)._ready()
+	verify_no_more_interactions(mock)
+	
+	# try on Godot class
+	var mocked_tcp_server :TCP_Server = mock(TCP_Server)
+	assert_object(mocked_tcp_server).is_not_null()
+	
+	mocked_tcp_server.is_listening()
+	mocked_tcp_server.is_connection_available()
+	verify(mocked_tcp_server).is_listening()
+	verify(mocked_tcp_server).is_connection_available()
+	verify_no_more_interactions(mocked_tcp_server)

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -707,7 +707,7 @@ func test_mock_snake_case_named_class_by_resource_path():
 	verify_no_more_interactions(mock_b)
 	
 func test_mock_snake_case_named_godot_class_by_name():
-		# try on Godot class
+	# try on Godot class
 	var mocked_tcp_server :TCP_Server = mock("TCP_Server")
 	assert_object(mocked_tcp_server).is_not_null()
 	

--- a/addons/gdUnit3/test/mocker/resources/snake_case.gd
+++ b/addons/gdUnit3/test/mocker/resources/snake_case.gd
@@ -1,0 +1,16 @@
+extends Reference
+
+
+# Declare member variables here. Examples:
+# var a = 2
+# var b = "text"
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+#func _process(delta):
+#	pass

--- a/addons/gdUnit3/test/mocker/resources/snake_case_class_name.gd
+++ b/addons/gdUnit3/test/mocker/resources/snake_case_class_name.gd
@@ -1,0 +1,17 @@
+class_name snake_case_class_name
+extends Reference
+
+
+# Declare member variables here. Examples:
+# var a = 2
+# var b = "text"
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+#func _process(delta):
+#	pass

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -292,7 +292,7 @@ func test_spy_snake_case_named_class_by_class():
 	verify(spy)._ready()
 	verify_no_more_interactions(spy)
 	
-		# try on Godot class
+	# try on Godot class
 	var spy_tcp_server :TCP_Server = spy(TCP_Server.new())
 	assert_object(spy_tcp_server).is_not_null()
 	

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -266,3 +266,38 @@ class ClassWithStaticFunctions:
 func test_create_spy_static_func_untyped():
 	var instance = spy(ClassWithStaticFunctions.new())
 	assert_object(instance).is_not_null()
+
+func test_spy_snake_case_named_class_by_resource_path():
+	var instance_a = load("res://addons/gdUnit3/test/mocker/resources/snake_case.gd").new()
+	var spy_a = spy(instance_a)
+	assert_object(spy_a).is_not_null()
+	
+	spy_a._ready()
+	verify(spy_a)._ready()
+	verify_no_more_interactions(spy_a)
+	
+	var instance_b = load("res://addons/gdUnit3/test/mocker/resources/snake_case_class_name.gd").new()
+	var spy_b = spy(instance_b)
+	assert_object(spy_b).is_not_null()
+	
+	spy_b._ready()
+	verify(spy_b)._ready()
+	verify_no_more_interactions(spy_b)
+
+func test_spy_snake_case_named_class_by_class():
+	var spy = spy(snake_case_class_name.new())
+	assert_object(spy).is_not_null()
+	
+	spy._ready()
+	verify(spy)._ready()
+	verify_no_more_interactions(spy)
+	
+		# try on Godot class
+	var spy_tcp_server :TCP_Server = spy(TCP_Server.new())
+	assert_object(spy_tcp_server).is_not_null()
+	
+	spy_tcp_server.is_listening()
+	spy_tcp_server.is_connection_available()
+	verify(spy_tcp_server).is_listening()
+	verify(spy_tcp_server).is_connection_available()
+	verify_no_more_interactions(spy_tcp_server)

--- a/project.godot
+++ b/project.godot
@@ -608,6 +608,11 @@ _global_script_classes=[ {
 "class": "_TestSuiteScannerTest",
 "language": "GDScript",
 "path": "res://addons/gdUnit3/test/core/_TestSuiteScannerTest.gd"
+}, {
+"base": "Reference",
+"class": "snake_case_class_name",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/test/mocker/resources/snake_case_class_name.gd"
 } ]
 _global_script_class_icons={
 "AdvancedTestClass": "",
@@ -729,7 +734,8 @@ _global_script_class_icons={
 "Udo": "",
 "_TestCase": "",
 "_TestSuiteScanner": "",
-"_TestSuiteScannerTest": ""
+"_TestSuiteScannerTest": "",
+"snake_case_class_name": ""
 }
 
 [application]


### PR DESCRIPTION
- clazz double was run into issues when the source class name is snake case.
  the doubled class was extending by name where is not supports snake case format
  to fix use the full class path to extend