### PR TITLE
Make AssetLib users happy.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Exclude files not needed for AssetLib users.
+
+/.gitattributes        export-ignore
+/.gitignore            export-ignore
+/default_env.tres      export-ignore
+/icon.png              export-ignore
+/LICENSE               export-ignore
+/project.godot         export-ignore
+/process_example.txt   export-ignore
+/README.md             export-ignore


### PR DESCRIPTION
By excluding files outside the `/addons` directory the AssetLib download only contains necessary files making users happy.

You can check ie with https://github.com/bitwes/Gut/blob/master/.gitattributes and what its AssetLib result is.