### PR TITLE
GD-48: Fixed mock and spy fail on class with default build in types

### DIFF
--- a/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
@@ -83,6 +83,135 @@ func test_parse_arguments():
 	assert_array(_parser.parse_arguments("func get_value( type := ENUM_A) -> int:"))\
 		.contains_exactly([GdFunctionArgument.new("type", "", "ENUM_A")])
 
+func test_parse_arguments_default_build_in_type_String():
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2=\"default\"):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "\"default\"")])
+	
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :=\"default\"):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "\"default\"")])
+	
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :String =\"default\"):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "String", "\"default\"")])
+
+func test_parse_arguments_default_build_in_type_Boolean():
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2=false):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "false")])
+	
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :=false):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "false")])
+	
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :bool=false):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "bool", "false")])
+
+func test_parse_arguments_default_build_in_type_Real():
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2=3.14):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "3.14")])
+	
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :=3.14):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "3.14")])
+	
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :float=3.14):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "float", "3.14")])
+
+func test_parse_arguments_default_build_in_type_Array():
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Array=[]):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "Array", "[]")])
+	
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Array=Array()):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "Array", "Array()")])
+	
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Array=[1, 2, 3]):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "Array", "[1,2,3]")])
+	
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :=[1, 2, 3]):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "[1,2,3]")])
+	
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2=[]):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "[]")])
+	
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Array=[1, 2, 3], arg3 := false):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "Array", "[1,2,3]"),
+			GdFunctionArgument.new("arg3", "", "false")])
+
+func test_parse_arguments_default_build_in_type_Color():
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2=Color.red):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "Color.red")])
+	
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :=Color.red):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "Color.red")])
+	
+	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Color=Color.red):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "Color", "Color.red")])
+
+func test_parse_arguments_default_build_in_type_Vector():
+	assert_array(_parser.parse_arguments("func bar(arg1 :String, arg2 =Vector3.FORWARD):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "Vector3.FORWARD")])
+	
+	assert_array(_parser.parse_arguments("func bar(arg1 :String, arg2 :=Vector3.FORWARD):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "Vector3.FORWARD")])
+	
+	assert_array(_parser.parse_arguments("func bar(arg1 :String, arg2 :Vector3=Vector3.FORWARD):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "Vector3", "Vector3.FORWARD")])
+
+func test_parse_arguments_default_build_in_type_AABB():
+	assert_array(_parser.parse_arguments("func bar(arg1 :String, arg2 := AABB()):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "AABB()")])
+	
+	assert_array(_parser.parse_arguments("func bar(arg1 :String, arg2 :AABB=AABB()):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "AABB", "AABB()")])
+
+func test_parse_arguments_default_build_in_types():
+	assert_array(_parser.parse_arguments("func bar(arg1 :String, arg2 := Vector3.FORWARD, aabb := AABB()):")) \
+		.contains_exactly([
+			GdFunctionArgument.new("arg1", "String"),
+			GdFunctionArgument.new("arg2", "", "Vector3.FORWARD"),
+			GdFunctionArgument.new("aabb", "", "AABB()")])
 
 func test_parse_arguments_no_function():
 	assert_array(_parser.parse_arguments("var x:=10")) \

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -800,7 +800,7 @@ func test_mock_snake_case_named_class_by_class():
 	verify(mocked_tcp_server).is_connection_available()
 	verify_no_more_interactions(mocked_tcp_server)
 
-func test_mock_func_with_default_place_in_type():
+func test_mock_func_with_default_build_in_type():
 	var mock :ClassWithDefaultBuildIntTypes = mock(ClassWithDefaultBuildIntTypes)
 	assert_object(mock).is_not_null()
 	# call with default arg

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -799,3 +799,20 @@ func test_mock_snake_case_named_class_by_class():
 	verify(mocked_tcp_server).is_listening()
 	verify(mocked_tcp_server).is_connection_available()
 	verify_no_more_interactions(mocked_tcp_server)
+
+func test_mock_func_with_default_place_in_type():
+	var mock :ClassWithDefaultBuildIntTypes = mock(ClassWithDefaultBuildIntTypes)
+	assert_object(mock).is_not_null()
+	# call with default arg
+	mock.foo("abc")
+	mock.bar("def")
+	verify(mock).foo("abc", Color.red)
+	verify(mock).bar("def", Vector3.FORWARD, AABB())
+	verify_no_more_interactions(mock)
+	
+	# call with custom color arg
+	mock.foo("abc", Color.blue)
+	mock.bar("def", Vector3.DOWN, AABB(Vector3.ONE, Vector3.ZERO))
+	verify(mock).foo("abc", Color.blue)
+	verify(mock).bar("def", Vector3.DOWN, AABB(Vector3.ONE, Vector3.ZERO))
+	verify_no_more_interactions(mock)

--- a/addons/gdUnit3/test/mocker/resources/ClassWithDefaultBuildIntTypes.gd
+++ b/addons/gdUnit3/test/mocker/resources/ClassWithDefaultBuildIntTypes.gd
@@ -1,0 +1,8 @@
+class_name ClassWithDefaultBuildIntTypes
+extends Reference
+
+func foo(value :String, color := Color.red):
+	pass
+
+func bar(value :String, direction := Vector3.FORWARD, aabb := AABB()):
+	pass

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -364,3 +364,20 @@ func test_spy_verify_emit_signal():
 	spy_instance.bar(1)
 	verify(spy_instance, 0).emit_signal("test_signal_a", "aa")
 	verify(spy_instance, 1).emit_signal("test_signal_b", "bb", true)
+
+func test_spy_func_with_default_place_in_type():
+	var spy_instance :ClassWithDefaultBuildIntTypes = spy(ClassWithDefaultBuildIntTypes.new())
+	assert_object(spy_instance).is_not_null()
+	# call with default arg
+	spy_instance.foo("abc")
+	spy_instance.bar("def")
+	verify(spy_instance).foo("abc", Color.red)
+	verify(spy_instance).bar("def", Vector3.FORWARD, AABB())
+	verify_no_more_interactions(spy_instance)
+	
+	# call with custom args
+	spy_instance.foo("abc", Color.blue)
+	spy_instance.bar("def", Vector3.DOWN, AABB(Vector3.ONE, Vector3.ZERO))
+	verify(spy_instance).foo("abc", Color.blue)
+	verify(spy_instance).bar("def", Vector3.DOWN, AABB(Vector3.ONE, Vector3.ZERO))
+	verify_no_more_interactions(spy_instance)

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -365,7 +365,7 @@ func test_spy_verify_emit_signal():
 	verify(spy_instance, 0).emit_signal("test_signal_a", "aa")
 	verify(spy_instance, 1).emit_signal("test_signal_b", "bb", true)
 
-func test_spy_func_with_default_place_in_type():
+func test_spy_func_with_default_build_in_type():
 	var spy_instance :ClassWithDefaultBuildIntTypes = spy(ClassWithDefaultBuildIntTypes.new())
 	assert_object(spy_instance).is_not_null()
 	# call with default arg

--- a/project.godot
+++ b/project.godot
@@ -89,6 +89,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gdUnit3/test/resources/core/City.gd"
 }, {
+"base": "Reference",
+"class": "ClassWithDefaultBuildIntTypes",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/test/mocker/resources/ClassWithDefaultBuildIntTypes.gd"
+}, {
 "base": "Resource",
 "class": "ClassWithNameA",
 "language": "GDScript",
@@ -656,6 +661,7 @@ _global_script_class_icons={
 "ChainedArgumentMatcher": "",
 "ChainedArgumentMatcherTest": "",
 "City": "",
+"ClassWithDefaultBuildIntTypes": "",
 "ClassWithNameA": "",
 "ClassWithNameB": "",
 "ClassWithPoolStringArrayFunc": "",


### PR DESCRIPTION
- parsing function arguments was not handling build in types
  the value was splitted up by using 'tokenize_value' from 'Color.red' into 'Color' and 'red'
  fixes by parsiong the full value until next arg or enf of function
- the parsed arg name was handled by ValueToken as typed value, this was resulting in wrong type
  'aabb' was interpreted as an TYPE_INT (hex)
  so i introduced to use the plain value instead to fix