### PR TITLE
GD-55: Added timeout argument to test case

### DIFF
--- a/addons/gdUnit3/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit3/src/GdUnitTestSuite.gd
@@ -51,6 +51,11 @@ func error_as_string(error_number :int) -> String:
 func auto_free(obj):
 	return GdUnitTools.register_auto_free(obj, get_meta("MEMORY_POOL"))
 
+# configue test case to expect failing by a timeout by given value is reached
+func expect_fail_with_timeout(timeout :int) -> void:
+	# TODO configure current test case to expect fail by timeout
+	pass
+
 # Creates a new directory under the temporary directory *user://tmp*
 # Useful for storing data during test execution. 
 # The directory is automatically deleted after test suite execution

--- a/addons/gdUnit3/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit3/src/GdUnitTestSuite.gd
@@ -41,6 +41,11 @@ func skip(skipped :bool) -> void:
 func is_skipped() -> bool:
 	return get_meta("gd_skipped") if has_meta("gd_skipped") else false
 
+
+var __active_test_case :String
+func set_active_test_case(test_case :String) -> void:
+	__active_test_case = test_case
+
 # === Tools ====================================================================
 # Mapps Godot error number to a readable error message. See at ERROR
 # https://docs.godotengine.org/de/stable/classes/class_@globalscope.html#enum-globalscope-error
@@ -51,10 +56,11 @@ func error_as_string(error_number :int) -> String:
 func auto_free(obj):
 	return GdUnitTools.register_auto_free(obj, get_meta("MEMORY_POOL"))
 
-# configue test case to expect failing by a timeout by given value is reached
-func expect_fail_with_timeout(timeout :int) -> void:
-	# TODO configure current test case to expect fail by timeout
-	pass
+# Discard the error message triggered by a timeout (interruption).
+# By default, an interrupted test is reported as an error.
+# This function allows you to change the message to Success when an interrupted error is reported.
+func discard_error_interupted_by_timeout() -> void:
+	GdUnitTools.register_expect_interupted_by_timeout(self, __active_test_case)
 
 # Creates a new directory under the temporary directory *user://tmp*
 # Useful for storing data during test execution. 

--- a/addons/gdUnit3/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitArrayAssertImpl.gd
@@ -24,7 +24,8 @@ func report_error(error :String) -> GdUnitArrayAssert:
 
 # -------- Base Assert wrapping ------------------------------------------------
 func has_error_message(expected: String) -> GdUnitArrayAssert:
-	_base.has_error_message(expected)
+	# normalize text to get rid of windows vs unix line formatting
+	_base.has_error_message(GdUnitTools.normalize_text(expected))
 	return self
 
 func starts_with_error_message(expected: String) -> GdUnitArrayAssert:

--- a/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
@@ -17,8 +17,9 @@ static func _get_line_number() -> int:
 	var failure_line := -1
 	while not stack_trace.empty():
 		var stack_info = stack_trace.pop_front()
-		var source :String = stack_info.get("function")
-		if source == "execute_test_case":
+		var function :String = stack_info.get("function")
+		var source :String = stack_info.get("source")
+		if function == "execute" and source.find("/_TestCase.gd"):
 			return failure_line
 		failure_line = stack_info.get("line")
 	# if no GdUnitExecutor in the stacktrace then is possible called in a yield stack

--- a/addons/gdUnit3/src/core/GdObjects.gd
+++ b/addons/gdUnit3/src/core/GdObjects.gd
@@ -677,11 +677,3 @@ static func markTextDifferences(text1 :String, text2 :String, lcsList :PoolStrin
 				word2LastIndex += 1
 
 	return stringBuffer
-
-
-# Normalizes given string by deleting \n, \t and extra spaces.
-static func normalizeText(text :String) -> String:
-	#text = text.trim();
-	text = text.replace("\n", " ");
-	text = text.replace("\t", " ");
-	return text.replace("  ", " ");

--- a/addons/gdUnit3/src/core/GdUnitRunner.gd
+++ b/addons/gdUnit3/src/core/GdUnitRunner.gd
@@ -58,14 +58,14 @@ func _process(delta):
 			if _test_suites_to_process.empty():
 				_state = STOP
 			else:
-				set_process(false)
 				# process next test suite
 				var test_suite := _test_suites_to_process.pop_front() as GdUnitTestSuite
 				var fs = _executor.execute(test_suite)
 				# is yielded than wait for completed
-				if fs is GDScriptFunctionState:
+				if GdUnitTools.is_yielded(fs):
+					set_process(false)
 					yield(fs, "completed")
-				set_process(true)
+					set_process(true)
 		STOP:
 			_state = EXIT
 			# give the engine small amount time to finish the rpc

--- a/addons/gdUnit3/src/core/GdUnitTools.gd
+++ b/addons/gdUnit3/src/core/GdUnitTools.gd
@@ -255,6 +255,10 @@ static func resource_as_string(resource_path :String) -> String:
 	file.close()
 	return file_content
 
+static func normalize_text(text :String) -> String:
+	return text.replace("\r", "");
+
+
 static func free_instance(instance :Object):
 	# needs to manually exculde JavaClass
 	# see https://github.com/godotengine/godot/issues/44932
@@ -332,3 +336,7 @@ static func clear_push_errors() -> void:
 	var runner = Engine.get_meta("GdUnitRunner")
 	if runner != null:
 		runner.clear_push_errors()
+
+static func register_expect_interupted_by_timeout(test_suite :Node, test_case_name :String) -> void:
+	var test_case = test_suite.find_node(test_case_name, false, false)
+	test_case.expect_to_interupt()

--- a/addons/gdUnit3/src/core/GdUnitTools.gd
+++ b/addons/gdUnit3/src/core/GdUnitTools.gd
@@ -298,6 +298,11 @@ static func is_auto_free_registered(obj, pool :int) -> bool:
 	var obj_pool := _objects_to_delete[pool] as Array
 	return obj_pool.has(obj)
 
+
+# test is given object a valid 'GDScriptFunctionState'
+static func is_yielded(obj) -> bool:
+	return obj is GDScriptFunctionState and obj.is_valid()
+
 # runs over all registered files and closes it
 static func run_auto_close():
 	while not _files_to_close.empty():

--- a/addons/gdUnit3/src/core/_TestCase.gd
+++ b/addons/gdUnit3/src/core/_TestCase.gd
@@ -1,15 +1,28 @@
 class_name _TestCase
 extends Node
 
+# default timeout 5min
+const DEFAULT_TIMEOUT :int = 1000 * 60 * 5
+const ARGUMENT_TIMEOUT := "timeout"
+
 var _iterations: int = 1
 var _seed: int
 var _fuzzer_func: String = ""
 var _line_number: int = -1
 var _script_path: String
-var _annotations: Dictionary = {}
 var _skipped := false
 
-func _init(name: String, line_number: int, script_path: String, fuzzer: String = "", iterations: int = 1, seed_ :int = -1, skipped := false) -> void:
+var _timer : Timer = Timer.new()
+var _fs
+var _aborted :bool = false
+var _timeout :int
+
+func _init() -> void:
+	add_child(_timer)
+	_timer.set_one_shot(true)
+	_timer.connect('timeout', self, '_test_case_timeout')
+
+func configure(name: String, line_number: int, script_path: String, timeout :int = DEFAULT_TIMEOUT, fuzzer: String = "", iterations: int = 1, seed_ :int = -1, skipped := false) -> _TestCase:
 	set_name(name)
 	_line_number = line_number
 	if not fuzzer.empty():
@@ -18,12 +31,45 @@ func _init(name: String, line_number: int, script_path: String, fuzzer: String =
 	_seed = seed_
 	_script_path = script_path
 	_skipped = skipped
+	_timeout = timeout
+	return self
+
+func execute(fuzzer :Fuzzer = null) :
+	if fuzzer:
+		if fuzzer._iteration_index == 1:
+			set_timeout()
+		_fs = get_parent().call(name, fuzzer)
+	else:
+		set_timeout()
+		_fs = get_parent().call(name)
+	if GdUnitTools.is_yielded(_fs):
+		yield(_fs, "completed")
+	return _fs
+
+func set_timeout():
+	var time :float = _timeout / 1000.0
+	#prints(get_name(), "set testcase timeout to %d ms" % _timeout)
+	_timer.set_wait_time(time)
+	_timer.set_autostart(false)
+	_timer.start()
+
+func _test_case_timeout():
+	_aborted = true
+	if _fs is GDScriptFunctionState:
+		yield(get_tree(), "idle_frame")
+		_fs.emit_signal("completed")
+
+func is_aborted() -> bool:
+	return _aborted
 
 func line_number() -> int:
 	return _line_number
 
 func iterations() -> int:
 	return _iterations
+
+func timeout() -> int:
+	return _timeout
 
 func seed_value() -> int:
 	return _seed
@@ -52,6 +98,7 @@ static func serialize(test_case: _TestCase) -> Dictionary:
 	serialized["name"] = test_case.get_name()
 	serialized["line_number"] = test_case.line_number()
 	serialized["script_path"] = test_case.script_path()
+	serialized["timeout"] = test_case.timeout()
 	serialized["fuzzer"] = test_case.fuzzer_func()
 	serialized["iterations"] = test_case.iterations()
 	serialized["seed"] = test_case.seed_value()
@@ -60,11 +107,15 @@ static func serialize(test_case: _TestCase) -> Dictionary:
 
 static func deserialize(serialized: Dictionary) -> _TestCase:
 	var instance = load("res://addons/gdUnit3/src/core/_TestCase.gd")
-	return instance.new(
+	return instance.new().configure(
 		serialized["name"], 
 		serialized["line_number"],
 		serialized["script_path"],
+		serialized["timeout"],
 		serialized["fuzzer"],
 		serialized["iterations"],
 		serialized["seed"],
 		serialized["skipped"])
+
+func _to_string():
+	return "%s :%d (%dms)" % [get_name(), _line_number, _timeout]

--- a/addons/gdUnit3/src/core/_TestCase.gd
+++ b/addons/gdUnit3/src/core/_TestCase.gd
@@ -11,10 +11,11 @@ var _fuzzer_func: String = ""
 var _line_number: int = -1
 var _script_path: String
 var _skipped := false
+var _expect_to_interupt := false
 
 var _timer : Timer = Timer.new()
 var _fs
-var _aborted :bool = false
+var _interupted :bool = false
 var _timeout :int
 
 func _init() -> void:
@@ -54,13 +55,19 @@ func set_timeout():
 	_timer.start()
 
 func _test_case_timeout():
-	_aborted = true
+	_interupted = true
 	if _fs is GDScriptFunctionState:
 		yield(get_tree(), "idle_frame")
 		_fs.emit_signal("completed")
 
-func is_aborted() -> bool:
-	return _aborted
+func is_interupted() -> bool:
+	return _interupted
+
+func expect_to_interupt() -> void:
+	_expect_to_interupt = true
+
+func is_expect_interupted() -> bool:
+	 return _expect_to_interupt
 
 func line_number() -> int:
 	return _line_number

--- a/addons/gdUnit3/src/core/_TestSuiteScanner.gd
+++ b/addons/gdUnit3/src/core/_TestSuiteScanner.gd
@@ -117,10 +117,11 @@ func _parse_and_add_test_cases(test_suite :GdUnitTestSuite, resource_path :Strin
 		if test_cases_to_find.has(func_name):
 			test_cases_to_find.erase(func_name)
 			# grap test arguments
+			var timeout = _script_parser.parse_argument(row, _TestCase.ARGUMENT_TIMEOUT, _TestCase.DEFAULT_TIMEOUT)
 			var iterations = _script_parser.parse_argument(row, Fuzzer.ARGUMENT_ITERATIONS, Fuzzer.ITERATION_DEFAULT_COUNT)
 			var seed_value = _script_parser.parse_argument(row, Fuzzer.ARGUMENT_SEED , -1)
 			var fuzzer_func := _script_parser.parse_fuzzer(row)
-			test_suite.add_child(_TestCase.new(func_name, line_number, resource_path, fuzzer_func, iterations, seed_value))
+			test_suite.add_child(_TestCase.new().configure(func_name, line_number, resource_path, timeout, fuzzer_func, iterations, seed_value))
 	
 	file.close()
 

--- a/addons/gdUnit3/src/ui/parts/InspectorStatusBar.gd
+++ b/addons/gdUnit3/src/ui/parts/InspectorStatusBar.gd
@@ -29,7 +29,10 @@ func _on_event(event :GdUnitEvent) -> void:
 		GdUnitEvent.TESTCASE_BEFORE:
 			pass
 		GdUnitEvent.TESTRUN_AFTER:
-			status_changed(0, event.is_failed())
+			if event.is_error():
+				status_changed(event.is_error(), 0)
+			else:
+				status_changed(0, event.is_failed())
 		GdUnitEvent.TESTSUITE_BEFORE:
 			pass
 		GdUnitEvent.TESTSUITE_AFTER:

--- a/addons/gdUnit3/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit3/src/ui/parts/InspectorTreeMainPanel.gd
@@ -165,7 +165,8 @@ func set_state_failed(item :TreeItem) -> void:
 
 func set_state_error(item :TreeItem) -> void:
 	item.set_meta(META_GDUNIT_STATE, STATE.ERROR)
-	item.set_custom_color(0, Color.lightgreen)
+	item.set_custom_color(0, Color.darkred)
+	item.set_suffix(0, "timeout! " + item.get_suffix(0))
 	item.set_icon(0, ICON_TEST_ERROR)
 	item.collapsed = false
 
@@ -204,6 +205,8 @@ func update_state(item: TreeItem, event :GdUnitEvent) -> void:
 			set_state_warnings(item)
 		if event.is_failed():
 			set_state_failed(item)
+		if event.is_error():
+			set_state_error(item)
 		for report in event.reports():
 			add_report(item, report)
 	set_state_orphan(item, event)

--- a/addons/gdUnit3/test/GdUnitTestCaseTimeoutTest.gd
+++ b/addons/gdUnit3/test/GdUnitTestCaseTimeoutTest.gd
@@ -1,0 +1,105 @@
+# this test suite simulates long running test cases
+extends GdUnitTestSuite
+
+var _timer_start = 0
+const SECOND:int = 1000
+const MINUTE:int = SECOND*60
+
+var _before_arg
+var _test_arg
+
+func before():
+	# use some variables to test clone test suite works as expected
+	_before_arg = "---before---"
+
+func before_test():
+	_timer_start = OS.get_system_time_msecs()
+	_test_arg = "abc"
+
+# without custom timeout should execute the complete test
+func test_timeout_after_test_completes():
+	assert_str(_before_arg).is_equal("---before---")
+	var counter := 0
+	yield(get_tree().create_timer(1.0), "timeout")
+	prints("A","1s")
+	counter += 1
+	yield(get_tree().create_timer(1.0), "timeout")
+	prints("A","2s")
+	counter += 1
+	yield(get_tree().create_timer(1.0), "timeout")
+	prints("A","3s")
+	counter += 1
+	yield(get_tree().create_timer(2.0), "timeout")
+	prints("A","5s")
+	counter += 2
+	prints("A","end test test_timeout_after_test_completes")
+	assert_int(counter).is_equal(5)
+
+# set test timeout to 2s
+func test_timeout_2s(timeout=2000):
+	expect_fail_with_timeout(2000)
+	assert_str(_before_arg).is_equal("---before---")
+	prints("B", "0s")
+	yield(get_tree().create_timer(1.0), "timeout")
+	prints("B", "1s")
+	yield(get_tree().create_timer(1.0), "timeout")
+	prints("B", "2s")
+	yield(get_tree().create_timer(1.0), "timeout")
+	# this line should not reach if timeout aborts the test case after 2s
+	assert_bool(true).as_error_message("The test case must be abort after 2s").is_false()
+	prints("B", "3s")
+	prints("B", "end")
+
+# set test timeout to 4s
+func test_timeout_4s(timeout=4000):
+	expect_fail_with_timeout(4000)
+	assert_str(_before_arg).is_equal("---before---")
+	prints("C", "0s")
+	yield(get_tree().create_timer(1.0), "timeout")
+	prints("C", "1s")
+	yield(get_tree().create_timer(1.0), "timeout")
+	prints("C", "2s")
+	yield(get_tree().create_timer(1.0), "timeout")
+	prints("C", "3s")
+	yield(get_tree().create_timer(4.0), "timeout")
+	# this line should not reach if timeout aborts the test case after 4s
+	assert_bool(true).as_error_message("The test case must be abort after 4s").is_false()
+	prints("C", "7s")
+	prints("C", "end")
+
+func test_timeout_single_yield_wait(timeout=3000):
+	expect_fail_with_timeout(3000)
+	assert_str(_before_arg).is_equal("---before---")
+	prints("D", "0s")
+	yield(get_tree().create_timer(6.0), "timeout")
+	prints("D", "6s")
+	# this line should not reach if timeout aborts the test case after 3s
+	assert_bool(true).as_error_message("The test case must be abort after 3s").is_false()
+	prints("D", "end test test_timeout")
+
+func test_timeout_long_running_test_abort(timeout=4000):
+	expect_fail_with_timeout(4000)
+	assert_str(_before_arg).is_equal("---before---")
+	prints("E", "0s")
+	var start_time := OS.get_system_time_msecs()
+	var sec_start_time := OS.get_system_time_msecs()
+	
+	# simulate long running function
+	while true:
+		var x = 1
+		var elapsed_time := OS.get_system_time_msecs() - start_time
+		
+		var sec_time = OS.get_system_time_msecs() - sec_start_time
+		
+		yield(get_tree(), "idle_frame")
+		if sec_time > 1000:
+			sec_start_time = OS.get_system_time_msecs()
+			prints("E", LocalTime.now())
+		
+		# exit while after 10s
+		if elapsed_time > 1000 * 10:
+			break
+	
+	# this line should not reach if timeout aborts the test case after 4s
+	assert_bool(true).as_error_message("The test case must be abort after 4s").is_false()
+	prints("F", "end test test_timeout")

--- a/addons/gdUnit3/test/GdUnitTestCaseTimeoutTest.gd
+++ b/addons/gdUnit3/test/GdUnitTestCaseTimeoutTest.gd
@@ -13,6 +13,8 @@ func before():
 	_before_arg = "---before---"
 
 func before_test():
+	# set failing test to success if failed by timeout
+	discard_error_interupted_by_timeout()
 	_timer_start = OS.get_system_time_msecs()
 	_test_arg = "abc"
 
@@ -37,7 +39,6 @@ func test_timeout_after_test_completes():
 
 # set test timeout to 2s
 func test_timeout_2s(timeout=2000):
-	expect_fail_with_timeout(2000)
 	assert_str(_before_arg).is_equal("---before---")
 	prints("B", "0s")
 	yield(get_tree().create_timer(1.0), "timeout")
@@ -46,13 +47,12 @@ func test_timeout_2s(timeout=2000):
 	prints("B", "2s")
 	yield(get_tree().create_timer(1.0), "timeout")
 	# this line should not reach if timeout aborts the test case after 2s
-	assert_bool(true).as_error_message("The test case must be abort after 2s").is_false()
+	assert_bool(true).as_error_message("The test case must be interupted by a timeout after 2s").is_false()
 	prints("B", "3s")
 	prints("B", "end")
 
 # set test timeout to 4s
 func test_timeout_4s(timeout=4000):
-	expect_fail_with_timeout(4000)
 	assert_str(_before_arg).is_equal("---before---")
 	prints("C", "0s")
 	yield(get_tree().create_timer(1.0), "timeout")
@@ -63,26 +63,25 @@ func test_timeout_4s(timeout=4000):
 	prints("C", "3s")
 	yield(get_tree().create_timer(4.0), "timeout")
 	# this line should not reach if timeout aborts the test case after 4s
-	assert_bool(true).as_error_message("The test case must be abort after 4s").is_false()
+	assert_bool(true).as_error_message("The test case must be interupted by a timeout after 4s").is_false()
 	prints("C", "7s")
 	prints("C", "end")
 
 func test_timeout_single_yield_wait(timeout=3000):
-	expect_fail_with_timeout(3000)
 	assert_str(_before_arg).is_equal("---before---")
 	prints("D", "0s")
 	yield(get_tree().create_timer(6.0), "timeout")
 	prints("D", "6s")
 	# this line should not reach if timeout aborts the test case after 3s
-	assert_bool(true).as_error_message("The test case must be abort after 3s").is_false()
+	assert_bool(true).as_error_message("The test case must be interupted by a timeout after 3s").is_false()
 	prints("D", "end test test_timeout")
 
 func test_timeout_long_running_test_abort(timeout=4000):
-	expect_fail_with_timeout(4000)
 	assert_str(_before_arg).is_equal("---before---")
 	prints("E", "0s")
 	var start_time := OS.get_system_time_msecs()
 	var sec_start_time := OS.get_system_time_msecs()
+	var start := LocalTime.now()
 	
 	# simulate long running function
 	while true:
@@ -94,12 +93,23 @@ func test_timeout_long_running_test_abort(timeout=4000):
 		yield(get_tree(), "idle_frame")
 		if sec_time > 1000:
 			sec_start_time = OS.get_system_time_msecs()
-			prints("E", LocalTime.now())
+			prints("E", start.elapsed_since())
 		
 		# exit while after 10s
 		if elapsed_time > 1000 * 10:
 			break
 	
 	# this line should not reach if timeout aborts the test case after 4s
-	assert_bool(true).as_error_message("The test case must be abort after 4s").is_false()
+	assert_bool(true).as_error_message("The test case must be abort interupted by a timeout 4s").is_false()
 	prints("F", "end test test_timeout")
+
+func test_timeout_fuzzer(fuzzer := Fuzzers.rangei(-23, 22), timeout=2000):
+	var value = fuzzer.next_value()
+	# wait each iteration 200ms 
+	yield(get_tree().create_timer(0.200), "timeout")
+
+	# we expects the test is interupped after 10 iterations because each test takes 200ms
+	# and the test should not longer run than 2000ms
+	assert_int(fuzzer.iteration_index())\
+		.as_error_message("The test must be interupted after around 10 iterations")\
+		.is_less_equal(10)

--- a/addons/gdUnit3/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -83,7 +83,7 @@ func test_contains_exactly():
 	assert_array([1, 2, 3, 4, 5], GdUnitAssert.EXPECT_FAIL) \
 		.contains_exactly([1, 4, 3, 2, 5])\
 		.has_error_message(expected_error_message)
-		
+
 func test_fluent():
 	assert_array([])\
 		.has_size(0)\

--- a/addons/gdUnit3/test/core/GdObjectsTest.gd
+++ b/addons/gdUnit3/test/core/GdObjectsTest.gd
@@ -169,15 +169,6 @@ func test_string_diff_empty():
 func test_string_diff():
 	assert_array(GdObjects.string_diff("Abc", "abc")).is_equal(["￵A￳abc", "￳A￵abc"])
 	
-func _test_longestCommonSubsequence():
-	assert_str("This is a test message").is_equal("This is a test Message")
-	var text1 := GdObjects.normalizeText("This is a test message")
-	var text2 := GdObjects.normalizeText("This is a gread test Message")
-	
-	prints(GdObjects.longestCommonSubsequence(text1, text2))
-	#prints(GdObjects.markTextDifferences(text1, text2, l, Color.green, Color.red))
-
-
 class TestClassForIsType:
 	var x
 

--- a/addons/gdUnit3/test/core/GdUnitToolsTest.gd
+++ b/addons/gdUnit3/test/core/GdUnitToolsTest.gd
@@ -146,3 +146,21 @@ func test_scan_dir() -> void:
 			"report_6",
 			"file_a",
 			"file_b"])
+
+func execute_timer(time:float):
+	yield(get_tree().create_timer(time),"timeout")
+
+func test_is_yielded() -> void:
+	assert_bool(GdUnitTools.is_yielded(null)).is_false()
+	assert_bool(GdUnitTools.is_yielded("abc")).is_false()
+	assert_bool(GdUnitTools.is_yielded(Resource.new())).is_false()
+	assert_bool(GdUnitTools.is_yielded(1)).is_false()
+	
+	assert_bool(GdUnitTools.is_yielded(GDScriptFunctionState.new())).is_false()
+	# start execution of a timer function with 2s
+	var fs = execute_timer(2.000)
+	# returnes function state is valid for 2s
+	assert_bool(GdUnitTools.is_yielded(fs)).is_true()
+	# wait more than 2s and the function state should be invalid
+	yield(get_tree().create_timer(2.100),"timeout")
+	assert_bool(GdUnitTools.is_yielded(fs)).is_false()

--- a/addons/gdUnit3/test/core/GdUnitToolsTest.gd
+++ b/addons/gdUnit3/test/core/GdUnitToolsTest.gd
@@ -156,7 +156,6 @@ func test_is_yielded() -> void:
 	assert_bool(GdUnitTools.is_yielded(Resource.new())).is_false()
 	assert_bool(GdUnitTools.is_yielded(1)).is_false()
 	
-	assert_bool(GdUnitTools.is_yielded(GDScriptFunctionState.new())).is_false()
 	# start execution of a timer function with 2s
 	var fs = execute_timer(2.000)
 	# returnes function state is valid for 2s

--- a/addons/gdUnit3/test/core/_TestSuiteScannerTest.gd
+++ b/addons/gdUnit3/test/core/_TestSuiteScannerTest.gd
@@ -119,3 +119,17 @@ func test_build_test_suite_path() -> void:
 	var source_path := tmp_path + "/Person.gd"
 	assert_str(_TestSuiteScanner.build_test_suite_path(source_path)).is_equal("user://tmp/test/projectX/entity/PersonTest.gd")
 
+func test_parse_and_add_test_cases() -> void:
+	var default_time := _TestCase.DEFAULT_TIMEOUT
+	var scanner = auto_free(_TestSuiteScanner.new())
+	var test_suite :GdUnitTestSuite = auto_free(GdUnitTestSuite.new())
+	var script_path := "res://addons/gdUnit3/test/core/resources/test_script_with_arguments.gd"
+	var test_case_names := PoolStringArray(["test_no_args", "test_with_timeout", "test_whith_fuzzer", "test_whith_fuzzer_iterations"])
+	scanner._parse_and_add_test_cases(test_suite, script_path, test_case_names)
+	assert_array(test_suite.get_children())\
+		.extractv(extr("get_name"), extr("timeout"), extr("fuzzer_func"), extr("iterations"))\
+		.contains_exactly([
+			tuple("test_no_args", default_time, "", 1),
+			tuple("test_with_timeout", 2000, "", 1),
+			tuple("test_whith_fuzzer", default_time, "fuzzer:=Fuzzers.rangei(-10,22)", Fuzzer.ITERATION_DEFAULT_COUNT),
+			tuple("test_whith_fuzzer_iterations", default_time, "fuzzer:=Fuzzers.rangei(-10,22)", 10)])

--- a/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
@@ -49,6 +49,14 @@ func test_parse_fuzzer_multiple_argument():
 	assert_that(_parser.parse_fuzzer("func test_foo(fuzzer = fuzzer(), arg1=42)")) \
 		.is_equal("fuzzer=fuzzer()")
 
+func test_parse_argument_timeout():
+	var DEFAULT_TIMEOUT = 1000
+	assert_that(_parser.parse_argument("func test_foo()", "timeout", DEFAULT_TIMEOUT)).is_equal(DEFAULT_TIMEOUT)
+	assert_that(_parser.parse_argument("func test_foo(timeout = 2000)", "timeout", DEFAULT_TIMEOUT)).is_equal(2000)
+	assert_that(_parser.parse_argument("func test_foo(timeout: = 2000)", "timeout", DEFAULT_TIMEOUT)).is_equal(2000)
+	assert_that(_parser.parse_argument("func test_foo(timeout:int = 2000)", "timeout", DEFAULT_TIMEOUT)).is_equal(2000)
+	assert_that(_parser.parse_argument("func test_foo(arg1 = false, timeout=2000)", "timeout", DEFAULT_TIMEOUT)).is_equal(2000)
+
 func test_parse_arguments():
 	assert_array(_parser.parse_arguments("func foo():")) \
 		.has_size(0)

--- a/addons/gdUnit3/test/core/resources/test_script_with_arguments.gd
+++ b/addons/gdUnit3/test/core/resources/test_script_with_arguments.gd
@@ -1,0 +1,14 @@
+extends Reference
+
+
+func test_no_args():
+	pass
+
+func test_with_timeout(timeout=2000):
+	pass
+	
+func test_whith_fuzzer(fuzzer := Fuzzers.rangei(-10, 22)):
+	pass
+
+func test_whith_fuzzer_iterations(fuzzer := Fuzzers.rangei(-10, 22), fuzzer_iterations = 10):
+	pass


### PR DESCRIPTION
- the new argument 'timeout' allows to specify a custom timeout value for each test in ms
  if a test runs longer than the timeout is configured the test will be interupped and fail with an error
- default test timeout is set to 5min