### PR TITLE
GD-62: Added project settings to disable/enable reporting detected orphans

### DIFF
--- a/addons/gdUnit3/plugin.gd
+++ b/addons/gdUnit3/plugin.gd
@@ -6,10 +6,11 @@ var _server_node
 var _gd_console:Node
 var _singleton :GdUnitSingleton = GdUnitSingleton.new()
 
+
 func _enter_tree():
 	Engine.set_meta("GdUnitEditorPlugin", self)
 	
-	GdUnitSettings.load_settings()
+	GdUnitSettings.setup()
 	
 	# install SignalHandler singleton
 	GdUnitSingleton.add_singleton(SignalHandler.SINGLETON_NAME, "res://addons/gdUnit3/src/core/event/SignalHandler.gd")

--- a/addons/gdUnit3/src/core/GdUnitMemoryPool.gd
+++ b/addons/gdUnit3/src/core/GdUnitMemoryPool.gd
@@ -19,9 +19,16 @@ var _monitors := {
 
 var _monitored_pool_order := Array()
 var _current :int
+var _orphan_detection_enabled :bool = true
 
 func _init():
 	set_name("GdUnitMemoryPool-%d" % get_instance_id())
+	configure(GdUnitSettings.is_verbose_orphans())
+
+func configure(orphan_detection :bool):
+	_orphan_detection_enabled = orphan_detection
+	if not _orphan_detection_enabled:
+		prints("!!! Reporting orphan nodes is disabled. Please check GdUnit settings.")
 
 func set_pool(obj :Object, pool_id :int, reset_monitor: bool = false) -> void:
 	_current = pool_id
@@ -42,4 +49,6 @@ func get_monitor(pool_id :int) -> GdUnitMemMonitor:
 	return _monitors.get(pool_id)
 
 func orphan_nodes() -> int:
-	return _monitors.get(_current).orphan_nodes()
+	if _orphan_detection_enabled:
+		return _monitors.get(_current).orphan_nodes()
+	return 0

--- a/addons/gdUnit3/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit3/src/core/GdUnitSettings.gd
@@ -25,7 +25,7 @@ const STDOUT_WITE_TO_FILE = CATEGORY_LOGGING + "log_path"
 # defaults
 # server connection timeout in minutes
 const DEFAULT_SERVER_TIMEOUT := 30
-# test case runtime timout in seconds
+# test case runtime timeout in seconds
 const DEFAULT_TEST_TIMEOUT := 60*5
 
 static func setup():

--- a/addons/gdUnit3/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit3/src/core/GdUnitSettings.gd
@@ -2,53 +2,50 @@ tool
 class_name GdUnitSettings
 extends Reference
 
-const CATEGORY = "gdunit3"
-const REPORT_ERROR_NOTIFICATIONS = CATEGORY + "/report/error_notification"
-const REPORT_ASSERT_WARNINGS = CATEGORY + "/report/assert/verbose_warnings"
-const REPORT_ASSERT_ERRORS = CATEGORY + "/report/assert/verbose_errors"
+const MAIN_CATEGORY = "gdunit3"
+# Common Settings
+const COMMON_SETTINGS = MAIN_CATEGORY + "/settings"
+
+const SERVER_TIMEOUT = COMMON_SETTINGS + "/server_connection_timeout_minutes"
+const TEST_TIMEOUT = COMMON_SETTINGS + "/test_timeout_seconds"
+
+# Report Setiings
+const REPORT_SETTINGS = MAIN_CATEGORY + "/report"
+const REPORT_ERROR_NOTIFICATIONS = REPORT_SETTINGS + "/error_notification"
+const REPORT_ORPHANS  = REPORT_SETTINGS + "/verbose_orphans"
+const REPORT_ASSERT_WARNINGS = REPORT_SETTINGS + "/assert/verbose_warnings"
+const REPORT_ASSERT_ERRORS   = REPORT_SETTINGS + "/assert/verbose_errors"
 
 # Godot stdout/logging settings
 const CATEGORY_LOGGING := "logging/file_logging/"
 const STDOUT_ENABLE_TO_FILE = CATEGORY_LOGGING + "enable_file_logging"
 const STDOUT_WITE_TO_FILE = CATEGORY_LOGGING + "log_path"
 
-static func load_settings():
-	var is_settings_changed := false
-	
-	if not ProjectSettings.has_setting(REPORT_ERROR_NOTIFICATIONS):
-		prints("GdUnit3: Set inital settings", REPORT_ERROR_NOTIFICATIONS)
-		var error_notification = {
-			"name": REPORT_ERROR_NOTIFICATIONS,
-			"type": TYPE_BOOL,
-			"hint": PROPERTY_HINT_NONE,
-			"hint_string": "Enable to report push error notifications"
-		}
-		ProjectSettings.set_setting(REPORT_ERROR_NOTIFICATIONS, false)
-		ProjectSettings.set_initial_value(REPORT_ERROR_NOTIFICATIONS, false)
-		ProjectSettings.add_property_info(error_notification)
-		is_settings_changed = true
-	
-	if not ProjectSettings.has_setting(REPORT_ASSERT_WARNINGS):
-		prints("GdUnit3: Set inital settings", REPORT_ASSERT_WARNINGS)
-		ProjectSettings.set_setting(REPORT_ASSERT_WARNINGS, false)
-		ProjectSettings.set_initial_value(REPORT_ASSERT_WARNINGS, false)
-		is_settings_changed = true
-	
-	if not ProjectSettings.has_setting(REPORT_ASSERT_ERRORS):
-		prints("GdUnit3: Set inital settings", REPORT_ASSERT_ERRORS)
-		ProjectSettings.set_setting(REPORT_ASSERT_ERRORS, true)
-		ProjectSettings.set_initial_value(REPORT_ASSERT_ERRORS, true)
-		is_settings_changed = true
-	
-	if is_settings_changed: 
-		var ret = ProjectSettings.save()
-		if ret != OK:
-			push_error(GdUnitTools.error_as_string(ret))
-			return
-		else:
-			prints("GdUnit3: Settings succesfully saved.")
-	else:
-		prints("GdUnit3: Settings successfully loaded.")
+
+# defaults
+# server connection timeout in minutes
+const DEFAULT_SERVER_TIMEOUT := 30
+# test case runtime timout in seconds
+const DEFAULT_TEST_TIMEOUT := 60*5
+
+static func setup():
+	create_property_if_need(SERVER_TIMEOUT, DEFAULT_SERVER_TIMEOUT)
+	create_property_if_need(TEST_TIMEOUT, DEFAULT_TEST_TIMEOUT)
+	create_property_if_need(REPORT_ERROR_NOTIFICATIONS, false)
+	create_property_if_need(REPORT_ORPHANS, true)
+	create_property_if_need(REPORT_ASSERT_ERRORS, true)
+	create_property_if_need(REPORT_ASSERT_WARNINGS, true)
+
+static func create_property_if_need(name :String, default) -> void:
+	if not ProjectSettings.has_setting(name):
+		prints("GdUnit3: Set inital settings '%s' to '%s'." % [name, str(default)])
+		ProjectSettings.set_setting(name, default)
+		ProjectSettings.set_initial_value(name, default)
+
+static func get_setting(name :String, default) :
+	if ProjectSettings.has_setting(name):
+		return ProjectSettings.get_setting(name)
+	return default
 
 static func is_report_push_errors() -> bool:
 	if ProjectSettings.has_setting(REPORT_ERROR_NOTIFICATIONS):
@@ -66,8 +63,19 @@ static func set_log_path(path :String) -> void:
 	ProjectSettings.set_setting(STDOUT_WITE_TO_FILE, path)
 	ProjectSettings.save()
 
+# the configured server connection timeout in ms
+static func server_timeout() -> int:
+	return get_setting(SERVER_TIMEOUT, DEFAULT_SERVER_TIMEOUT) * 60 * 1000
+
+# the configured test case timeout in ms
+static func test_timeout() -> int:
+	return get_setting(TEST_TIMEOUT, DEFAULT_TEST_TIMEOUT) * 1000
+
 static func is_verbose_assert_warnings() -> bool:
-	return ProjectSettings.get_setting(REPORT_ASSERT_WARNINGS)
+	return get_setting(REPORT_ASSERT_WARNINGS, true)
 
 static func is_verbose_assert_errors() -> bool:
-	return ProjectSettings.get_setting(REPORT_ASSERT_ERRORS)
+	return get_setting(REPORT_ASSERT_ERRORS, true)
+
+static func is_verbose_orphans() -> bool:
+	return get_setting(REPORT_ORPHANS, true)

--- a/addons/gdUnit3/src/core/_TestCase.gd
+++ b/addons/gdUnit3/src/core/_TestCase.gd
@@ -2,7 +2,7 @@ class_name _TestCase
 extends Node
 
 # default timeout 5min
-const DEFAULT_TIMEOUT :int = 1000 * 60 * 5
+const DEFAULT_TIMEOUT := -1
 const ARGUMENT_TIMEOUT := "timeout"
 
 var _iterations: int = 1
@@ -17,11 +17,13 @@ var _timer : Timer = Timer.new()
 var _fs
 var _interupted :bool = false
 var _timeout :int
+var _default_timeout :int
 
 func _init() -> void:
 	add_child(_timer)
 	_timer.set_one_shot(true)
 	_timer.connect('timeout', self, '_test_case_timeout')
+	_default_timeout = GdUnitSettings.test_timeout()
 
 func configure(name: String, line_number: int, script_path: String, timeout :int = DEFAULT_TIMEOUT, fuzzer: String = "", iterations: int = 1, seed_ :int = -1, skipped := false) -> _TestCase:
 	set_name(name)
@@ -32,7 +34,9 @@ func configure(name: String, line_number: int, script_path: String, timeout :int
 	_seed = seed_
 	_script_path = script_path
 	_skipped = skipped
-	_timeout = timeout
+	_timeout = _default_timeout
+	if timeout != DEFAULT_TIMEOUT:
+		_timeout = timeout
 	return self
 
 func execute(fuzzer :Fuzzer = null) :

--- a/addons/gdUnit3/src/network/Network.gd
+++ b/addons/gdUnit3/src/network/Network.gd
@@ -75,8 +75,9 @@ func _peer_connected(peer_id :int):
 	_connected_clients[peer_id] = true
 	# first available since Godot 3.2.4 RC 4
 	if _peer.has_method("set_peer_timeout"):
-		print_debug("Increase network peer timeout to 5min")
-		_peer.set_peer_timeout(peer_id, 60000, 60000*5, 60000*5)
+		var timeout := GdUnitSettings.server_timeout()
+		print_debug("Increase network peer timeout to %s" % LocalTime.elapsed(timeout))
+		_peer.set_peer_timeout(peer_id, 60000, timeout, timeout)
 	emit_signal("client_connected", peer_id)
 
 func _peer_disconnected(peer_id :int):

--- a/addons/gdUnit3/test/core/GdUnitMemoryPoolTest.gd
+++ b/addons/gdUnit3/test/core/GdUnitMemoryPoolTest.gd
@@ -1,0 +1,46 @@
+# GdUnit generated TestSuite
+class_name GdUnitMemoryPoolTest
+extends GdUnitTestSuite
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit3/src/core/GdUnitMemoryPool.gd'
+
+var _pool :GdUnitMemoryPool
+var _source :Object
+
+func before_test():
+	_source = Node.new()
+	_pool = GdUnitMemoryPool.new()
+	_pool.set_pool(_source, GdUnitMemoryPool.TEST_EXECUTE, true)
+
+func after_test():
+	_pool.free()
+	_source.free()
+
+func test_orphan_nodes_report_enabled() -> void:
+	# enable orphan detection
+	_pool.configure(true)
+	# create a orphan node
+	var orphan1 = Node.new()
+	var orphan2 = Node.new()
+	_pool.monitor_stop()
+	# we expect to detect one orphan node
+	assert_int(_pool.orphan_nodes()).is_equal(2)
+	
+	# manual cleanup
+	orphan1.free()
+	orphan2.free()
+
+func test_orphan_nodes_report_disabled() -> void:
+	# disable orphan detection
+	_pool.configure(false)
+	# create a orphan node
+	var orphan1 = Node.new()
+	var orphan2 = Node.new()
+	_pool.monitor_stop()
+	# we expect to detect one orphan node
+	assert_int(_pool.orphan_nodes()).is_equal(0)
+	
+	# manual cleanup
+	orphan1.free()
+	orphan2.free()

--- a/addons/gdUnit3/test/core/_TestSuiteScannerTest.gd
+++ b/addons/gdUnit3/test/core/_TestSuiteScannerTest.gd
@@ -120,7 +120,7 @@ func test_build_test_suite_path() -> void:
 	assert_str(_TestSuiteScanner.build_test_suite_path(source_path)).is_equal("user://tmp/test/projectX/entity/PersonTest.gd")
 
 func test_parse_and_add_test_cases() -> void:
-	var default_time := _TestCase.DEFAULT_TIMEOUT
+	var default_time := GdUnitSettings.test_timeout()
 	var scanner = auto_free(_TestSuiteScanner.new())
 	var test_suite :GdUnitTestSuite = auto_free(GdUnitTestSuite.new())
 	var script_path := "res://addons/gdUnit3/test/core/resources/test_script_with_arguments.gd"

--- a/project.godot
+++ b/project.godot
@@ -474,6 +474,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gdUnit3/src/core/GdUnitMemoryPool.gd"
 }, {
+"base": "GdUnitTestSuite",
+"class": "GdUnitMemoryPoolTest",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/test/core/GdUnitMemoryPoolTest.gd"
+}, {
 "base": "Reference",
 "class": "GdUnitMock",
 "language": "GDScript",
@@ -539,7 +544,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gdUnit3/src/network/GdUnitPushErrorHandler.gd"
 }, {
-"base": "Reference",
+"base": "Resource",
 "class": "GdUnitReport",
 "language": "GDScript",
 "path": "res://addons/gdUnit3/src/core/report/GdUnitReport.gd"
@@ -888,6 +893,7 @@ _global_script_class_icons={
 "GdUnitMemMonitor": "",
 "GdUnitMemMonitorTest": "",
 "GdUnitMemoryPool": "",
+"GdUnitMemoryPoolTest": "",
 "GdUnitMock": "",
 "GdUnitMockBuilder": "",
 "GdUnitMockBuilderTest": "",
@@ -974,12 +980,11 @@ enabled=PoolStringArray( "res://addons/gdUnit3/plugin.cfg" )
 
 [gdunit3]
 
-report/assert/verbose_warnings=false
 report/assert/verbose_errors=false
+report/assert/verbose_warnings=false
 
 [network]
 
-limits/tcp/connect_timeout_seconds=300
 limits/debugger_stdout/max_chars_per_second=60048
 limits/debugger_stdout/max_messages_per_frame=100
 limits/debugger_stdout/max_errors_per_second=1000


### PR DESCRIPTION
- added new project settings
  -- 'gdunit3/report/verbose_orphans'
     allowes to control orphan reporting
  -- 'gdunit3/settings/server_connection_timeout_minutes'
     allows to configure connection timeout of GdUnit report server
  -- 'gdunit3/settings/test_timeout_seconds'
     allows to configure the default test timeout in seconds