### PR TITLE
GD-76: Fix broken compatibility to Godot 3.2.x

### DIFF
--- a/.github/workflows/selftest-3.2.x.yml
+++ b/.github/workflows/selftest-3.2.x.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
         with:
           lfs: true
       - name: Setup

--- a/.github/workflows/selftest-3.2.x.yml
+++ b/.github/workflows/selftest-3.2.x.yml
@@ -5,7 +5,7 @@ jobs:
   testing:
     strategy:
       matrix:
-        godot: [3.2.2, 3.2.3]
+        godot: [3.2.3]
 
     name: GdUnit3 Selftest on Godot ${{ matrix.godot }}
     runs-on: ubuntu-latest

--- a/addons/gdUnit3/src/cmd/CmdCommandHandler.gd
+++ b/addons/gdUnit3/src/cmd/CmdCommandHandler.gd
@@ -8,8 +8,15 @@ var _cmd_options :CmdOptions
 # holds the command callbacks by key:<cmd_name>:String and value: [<cb single arg>, <cb multible args>]:Array
 var _command_func_refs :Dictionary
 
+# we only able to check fr function name since Godot 3.3.x
+var _enhanced_fr_test := false
+
 func _init(cmd_options :CmdOptions):
 	_cmd_options = cmd_options
+	var major :int = Engine.get_version_info()["major"]
+	var minor :int = Engine.get_version_info()["minor"]
+	if major == 3 and minor == 3:
+		_enhanced_fr_test = true
 
 # register a callback function for given command
 # cmd_name short name of the command
@@ -48,8 +55,8 @@ func _validate() -> Result:
 			errors.append("The command '%s' is unknown, verify your CmdOptions!" % cmd_name)
 		
 		# verify for multiple registered command callbacks
-		if fr != null:
-			var func_cb_name := fr.get_function()
+		if _enhanced_fr_test and fr != null:
+			var func_cb_name = fr.get_function()
 			if registers_func_cbs.has(func_cb_name):
 				var already_registered_cmd = registers_func_cbs[func_cb_name] 
 				errors.append("The function reference '%s' already registerd for command '%s'!" % [func_cb_name, already_registered_cmd])

--- a/addons/gdUnit3/src/core/GdUnitExecutor.gd
+++ b/addons/gdUnit3/src/core/GdUnitExecutor.gd
@@ -90,7 +90,7 @@ func suite_after(test_suite :GdUnitTestSuite) -> GDScriptFunctionState:
 		var fstate = test_suite.after()
 		if GdUnitTools.is_yielded(fstate):
 			yield(fstate, "completed")
-		reports.append_array(_report_collector.get_reports(STAGE_TEST_SUITE_AFTER))
+		GdUnitTools.append_array(reports, _report_collector.get_reports(STAGE_TEST_SUITE_AFTER))
 		GdUnitTools.run_auto_close()
 		_memory_pool.free_pool()
 		_memory_pool.monitor_stop()

--- a/addons/gdUnit3/src/core/GdUnitTools.gd
+++ b/addons/gdUnit3/src/core/GdUnitTools.gd
@@ -340,3 +340,12 @@ static func clear_push_errors() -> void:
 static func register_expect_interupted_by_timeout(test_suite :Node, test_case_name :String) -> void:
 	var test_case = test_suite.find_node(test_case_name, false, false)
 	test_case.expect_to_interupt()
+
+static func append_array(array, append :Array) -> void:
+	var major :int = Engine.get_version_info()["major"]
+	var minor :int = Engine.get_version_info()["minor"]
+	if major == 3 and minor == 3:
+		array.append_array(append)
+	else:
+		for element in append:
+			array.append(element)

--- a/addons/gdUnit3/src/core/report/GdUnitReportCollector.gd
+++ b/addons/gdUnit3/src/core/report/GdUnitReportCollector.gd
@@ -41,7 +41,7 @@ func get_reports(execution_states :int) -> Array:
 	var reports :Array = Array()
 	for state in ALL_REPORT_STATES:
 		if execution_states&state == state:
-			reports.append_array(get_reports_by_state(state))
+			GdUnitTools.append_array(reports, get_reports_by_state(state))
 	return reports
 
 func has_errors(execution_states :int) -> bool:

--- a/addons/gdUnit3/test/asserts/GdUnitVector3AssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitVector3AssertImplTest.gd
@@ -40,7 +40,7 @@ func test_is_equal_approx() -> void:
 
 func test_is_less() -> void:
 	assert_vector3(Vector3.ONE).is_less(Vector3.INF)
-	assert_vector3(Vector3(1.2, 1.000001, 1)).is_less(Vector3(1.2, 1.000002, 1))
+	assert_vector3(Vector3(1.2, 1.00001, 1)).is_less(Vector3(1.2, 1.00002, 1))
 	
 	# false test
 	assert_vector3(Vector3.ONE, GdUnitAssert.EXPECT_FAIL)\
@@ -59,14 +59,14 @@ func test_is_less_equal() -> void:
 	assert_vector3(Vector3.ONE, GdUnitAssert.EXPECT_FAIL)\
 		.is_less_equal(Vector3.ZERO)\
 		.has_error_message("Expecting to be less than or equal:\n '(0, 0, 0)' but was '(1, 1, 1)'")
-	assert_vector3(Vector3(1.2, 1.000002, 1), GdUnitAssert.EXPECT_FAIL)\
-		.is_less_equal(Vector3(1.2, 1.000001, 1))\
-		.has_error_message("Expecting to be less than or equal:\n '(1.2, 1.000001, 1)' but was '(1.2, 1.000002, 1)'")
+	assert_vector3(Vector3(1.2, 1.00002, 1), GdUnitAssert.EXPECT_FAIL)\
+		.is_less_equal(Vector3(1.2, 1.00001, 1))\
+		.has_error_message("Expecting to be less than or equal:\n '(1.2, 1.00001, 1)' but was '(1.2, 1.00002, 1)'")
 
 
 func test_is_greater() -> void:
 	assert_vector3(Vector3.INF).is_greater(Vector3.ONE)
-	assert_vector3(Vector3(1.2, 1.000002, 1)).is_greater(Vector3(1.2, 1.000001, 1))
+	assert_vector3(Vector3(1.2, 1.00002, 1)).is_greater(Vector3(1.2, 1.00001, 1))
 	
 	# false test
 	assert_vector3(Vector3.ZERO, GdUnitAssert.EXPECT_FAIL)\
@@ -86,9 +86,9 @@ func test_is_greater_equal() -> void:
 	assert_vector3(Vector3.ZERO, GdUnitAssert.EXPECT_FAIL)\
 		.is_greater_equal(Vector3.ONE)\
 		.has_error_message("Expecting to be greater than or equal:\n '(1, 1, 1)' but was '(0, 0, 0)'")
-	assert_vector3(Vector3(1.2, 1.000002, 1), GdUnitAssert.EXPECT_FAIL)\
-		.is_greater_equal(Vector3(1.2, 1.000003, 1))\
-		.has_error_message("Expecting to be greater than or equal:\n '(1.2, 1.000003, 1)' but was '(1.2, 1.000002, 1)'")
+	assert_vector3(Vector3(1.2, 1.00002, 1), GdUnitAssert.EXPECT_FAIL)\
+		.is_greater_equal(Vector3(1.2, 1.00003, 1))\
+		.has_error_message("Expecting to be greater than or equal:\n '(1.2, 1.00003, 1)' but was '(1.2, 1.00002, 1)'")
 
 func test_is_between(fuzzer = Fuzzers.rangev3(Vector3.ZERO, Vector3.ONE)):
 	var value :Vector3 = fuzzer.next_value()

--- a/addons/gdUnit3/test/cmd/CmdCommandHandlerTest.gd
+++ b/addons/gdUnit3/test/cmd/CmdCommandHandlerTest.gd
@@ -77,10 +77,10 @@ func test__validate_registerd_register_same_callback_twice():
 	var cmd_handler := CmdCommandHandler.new(_cmd_options)
 	cmd_handler.register_cb("-a", funcref(_cmd_instance, "cmd_a"))
 	cmd_handler.register_cb("-b", funcref(_cmd_instance, "cmd_a"))
-	
-	assert_result(cmd_handler._validate())\
-		.is_error()\
-		.contains_message("The function reference 'cmd_a' already registerd for command '-a'!")
+	if cmd_handler._enhanced_fr_test:
+		assert_result(cmd_handler._validate())\
+			.is_error()\
+			.contains_message("The function reference 'cmd_a' already registerd for command '-a'!")
 
 func test_execute_no_commands():
 	var cmd_handler := CmdCommandHandler.new(_cmd_options)


### PR DESCRIPTION
- With Godot 3.2.x array does not support 'append_array', which was introduced with Godot 3.3
  Compensation function added to GdUnitTools.append_array to be compatible
- vector3 tests was failing base on to high resolution, minimized by one decimal place
- CommandHandle was broken by using FuncRef:get_function() where not exists in Godot 3.2.x
  fixes by disabled the enhanced command register validation