### PR TITLE
GD-81: Allow assert_that on not built-in types

### DIFF
--- a/addons/gdUnit3/src/GdUnitAssert.gd
+++ b/addons/gdUnit3/src/GdUnitAssert.gd
@@ -8,6 +8,14 @@ const EXPECT_SUCCESS:int = 0
 const EXPECT_FAIL:int    = 1
 
 
+# Verifies that the current value is null.
+func is_null():
+	return self
+
+# Verifies that the current value is not null.
+func is_not_null():
+	return self
+
 # Verifies that the current value is equal to expected one.
 func is_equal(expected):
 	return self
@@ -27,8 +35,6 @@ func has_error_message(expected: String):
 func starts_with_error_message(expected: String):
 	return self
 
-func as_error_message(message :String):
-	return self
-
-func with_error_info(message :String):
+# Overrides the default failure message by given custom message 
+func override_failure_message(message :String):
 	return self

--- a/addons/gdUnit3/src/GdUnitAssert.gd
+++ b/addons/gdUnit3/src/GdUnitAssert.gd
@@ -31,7 +31,7 @@ func test_fail():
 func has_failure_message(expected: String):
 	return self
 
-# Verifies that the error starts with the given prefix.
+# Verifies that the failure starts with the given prefix.
 func starts_with_failure_message(expected: String):
 	return self
 

--- a/addons/gdUnit3/src/GdUnitAssert.gd
+++ b/addons/gdUnit3/src/GdUnitAssert.gd
@@ -28,11 +28,11 @@ func test_fail():
 	return self
 
 # Verifies the error message is equal to expected one.
-func has_error_message(expected: String):
+func has_failure_message(expected: String):
 	return self
 
 # Verifies that the error starts with the given prefix.
-func starts_with_error_message(expected: String):
+func starts_with_failure_message(expected: String):
 	return self
 
 # Overrides the default failure message by given custom message 

--- a/addons/gdUnit3/src/GdUnitAssert.gd
+++ b/addons/gdUnit3/src/GdUnitAssert.gd
@@ -27,7 +27,7 @@ func is_not_equal(expected):
 func test_fail():
 	return self
 
-# Verifies the error message is equal to expected one.
+# Verifies the failuremessage is equal to expected one.
 func has_failure_message(expected: String):
 	return self
 

--- a/addons/gdUnit3/src/GdUnitBoolAssert.gd
+++ b/addons/gdUnit3/src/GdUnitBoolAssert.gd
@@ -2,6 +2,15 @@
 class_name GdUnitBoolAssert
 extends GdUnitAssert
 
+
+# Verifies that the current value is null.
+func is_null() -> GdUnitBoolAssert:
+	return self
+
+# Verifies that the current value is not null.
+func is_not_null() -> GdUnitBoolAssert:
+	return self
+
 # Verifies that the current value is equal to the given one.
 func is_equal(expected) -> GdUnitBoolAssert:
 	return self
@@ -18,5 +27,5 @@ func is_true() -> GdUnitBoolAssert:
 func is_false() -> GdUnitBoolAssert:
 	return self
 
-func as_error_message(message :String) -> GdUnitBoolAssert:
+func override_failure_message(message :String) -> GdUnitBoolAssert:
 	return self

--- a/addons/gdUnit3/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit3/src/GdUnitTestSuite.gd
@@ -282,8 +282,10 @@ func assert_that(current, expect_result: int = GdUnitAssert.EXPECT_SUCCESS) -> G
 			return assert_dict(current, expect_result)
 		TYPE_ARRAY:
 			return assert_array(current, expect_result)
-		_:
+		TYPE_OBJECT:
 			return assert_object(current, expect_result)
+		_:
+			return GdUnitAssertImpl.new(self, current, expect_result)
 
 func assert_bool(current, expect_result: int = GdUnitAssert.EXPECT_SUCCESS) -> GdUnitBoolAssert:
 	return GdUnitBoolAssertImpl.new(self, current, expect_result)

--- a/addons/gdUnit3/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitArrayAssertImpl.gd
@@ -32,12 +32,8 @@ func starts_with_error_message(expected: String) -> GdUnitArrayAssert:
 	_base.starts_with_error_message(expected)
 	return self
 
-func as_error_message(message :String) -> GdUnitArrayAssert:
-	_base.as_error_message(message)
-	return self
-
-func with_error_info(message :String) -> GdUnitArrayAssert:
-	_base.with_error_info(message)
+func override_failure_message(message :String) -> GdUnitArrayAssert:
+	_base.override_failure_message(message)
 	return self
 
 func _notification(event):

--- a/addons/gdUnit3/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitArrayAssertImpl.gd
@@ -23,13 +23,13 @@ func report_error(error :String) -> GdUnitArrayAssert:
 	return self
 
 # -------- Base Assert wrapping ------------------------------------------------
-func has_error_message(expected: String) -> GdUnitArrayAssert:
+func has_failure_message(expected: String) -> GdUnitArrayAssert:
 	# normalize text to get rid of windows vs unix line formatting
-	_base.has_error_message(GdUnitTools.normalize_text(expected))
+	_base.has_failure_message(GdUnitTools.normalize_text(expected))
 	return self
 
-func starts_with_error_message(expected: String) -> GdUnitArrayAssert:
-	_base.starts_with_error_message(expected)
+func starts_with_failure_message(expected: String) -> GdUnitArrayAssert:
+	_base.starts_with_failure_message(expected)
 	return self
 
 func override_failure_message(message :String) -> GdUnitArrayAssert:

--- a/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
@@ -56,7 +56,7 @@ func report_error(error_message :String) -> GdUnitAssert:
 func test_fail():
 	return report_error(GdAssertMessages.error_not_implemented())
 
-func has_error_message(expected :String):
+func has_failure_message(expected :String):
 	var rtl := RichTextLabel.new()
 	rtl.bbcode_enabled = true
 	rtl.parse_bbcode(_current_error_message)
@@ -70,7 +70,7 @@ func has_error_message(expected :String):
 	return self
 
 
-func starts_with_error_message(expected :String):
+func starts_with_failure_message(expected :String):
 	var rtl := RichTextLabel.new()
 	rtl.bbcode_enabled = true
 	rtl.parse_bbcode(_current_error_message)

--- a/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
@@ -6,8 +6,7 @@ var _current
 var _is_failed :bool = false
 var _current_error_message :String = ""
 var _expect_fail :bool = false
-var _custom_error_message = null
-var _error_info = null
+var _custom_failure_message = null
 var _report_consumer :WeakRef
 
 # Scans the current stack trace for the root cause to extract the line number
@@ -50,12 +49,9 @@ func report_success() -> GdUnitAssert:
 func report_error(error_message :String) -> GdUnitAssert:
 	var line_number := _get_line_number()
 
-	if _custom_error_message == null:
-		var message := error_message
-		if _error_info != null:
-			message = _error_info + "\n" + error_message
-		return GdAssertReports.report_error(message, self, line_number)
-	return GdAssertReports.report_error(_custom_error_message, self, line_number)
+	if _custom_failure_message == null:
+		return GdAssertReports.report_error(error_message, self, line_number)
+	return GdAssertReports.report_error(_custom_failure_message, self, line_number)
 
 func test_fail():
 	return report_error(GdAssertMessages.error_not_implemented())
@@ -87,12 +83,8 @@ func starts_with_error_message(expected :String):
 		report_error(GdAssertMessages.error_not_same_error(current, expected))
 	return self
 
-func as_error_message(message :String):
-	_custom_error_message = message
-	return self
-
-func with_error_info(message :String):
-	_error_info = message
+func override_failure_message(message :String):
+	_custom_failure_message = message
 	return self
 
 func is_equal(expected) -> GdUnitAssert:

--- a/addons/gdUnit3/src/asserts/GdUnitBoolAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitBoolAssertImpl.gd
@@ -20,12 +20,12 @@ func report_error(error :String) -> GdUnitBoolAssert:
 	return self
 
 # -------- Base Assert wrapping ------------------------------------------------
-func has_error_message(expected: String) -> GdUnitBoolAssert:
-	_base.has_error_message(expected)
+func has_failure_message(expected: String) -> GdUnitBoolAssert:
+	_base.has_failure_message(expected)
 	return self
 
-func starts_with_error_message(expected: String) -> GdUnitBoolAssert:
-	_base.starts_with_error_message(expected)
+func starts_with_failure_message(expected: String) -> GdUnitBoolAssert:
+	_base.starts_with_failure_message(expected)
 	return self
 
 func override_failure_message(message :String) -> GdUnitBoolAssert:

--- a/addons/gdUnit3/src/asserts/GdUnitBoolAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitBoolAssertImpl.gd
@@ -5,7 +5,7 @@ var _base: GdUnitAssert
 
 func _init(caller :Object, current, expect_result: int):
 	_base = GdUnitAssertImpl.new(caller, current, expect_result)
-	if typeof(current) != TYPE_BOOL:
+	if current != null and typeof(current) != TYPE_BOOL:
 		report_error("GdUnitBoolAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 func __current() -> bool:
@@ -28,8 +28,8 @@ func starts_with_error_message(expected: String) -> GdUnitBoolAssert:
 	_base.starts_with_error_message(expected)
 	return self
 
-func as_error_message(message :String) -> GdUnitBoolAssert:
-	_base.as_error_message(message)
+func override_failure_message(message :String) -> GdUnitBoolAssert:
+	_base.override_failure_message(message)
 	return self
 
 func _notification(event):
@@ -38,6 +38,15 @@ func _notification(event):
 			_base.notification(event)
 			_base = null
 #-------------------------------------------------------------------------------
+# Verifies that the current value is null.
+func is_null() -> GdUnitBoolAssert:
+	_base.is_null()
+	return self
+
+# Verifies that the current value is not null.
+func is_not_null() -> GdUnitBoolAssert:
+	_base.is_not_null()
+	return self
 
 func is_equal(expected) -> GdUnitBoolAssert:
 	_base.is_equal(expected)

--- a/addons/gdUnit3/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -24,12 +24,12 @@ func report_error(error :String) -> GdUnitDictionaryAssert:
 	return self
 
 # -------- Base Assert wrapping ------------------------------------------------
-func has_error_message(expected: String) -> GdUnitDictionaryAssert:
-	_base.has_error_message(expected)
+func has_failure_message(expected: String) -> GdUnitDictionaryAssert:
+	_base.has_failure_message(expected)
 	return self
 
-func starts_with_error_message(expected: String) -> GdUnitDictionaryAssert:
-	_base.starts_with_error_message(expected)
+func starts_with_failure_message(expected: String) -> GdUnitDictionaryAssert:
+	_base.starts_with_failure_message(expected)
 	return self
 
 func override_failure_message(message :String) -> GdUnitDictionaryAssert:

--- a/addons/gdUnit3/src/asserts/GdUnitDictionaryAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitDictionaryAssertImpl.gd
@@ -32,12 +32,8 @@ func starts_with_error_message(expected: String) -> GdUnitDictionaryAssert:
 	_base.starts_with_error_message(expected)
 	return self
 
-func as_error_message(message :String) -> GdUnitDictionaryAssert:
-	_base.as_error_message(message)
-	return self
-
-func with_error_info(message :String) -> GdUnitDictionaryAssert:
-	_base.with_error_info(message)
+func override_failure_message(message :String) -> GdUnitDictionaryAssert:
+	_base.override_failure_message(message)
 	return self
 
 func _notification(event):

--- a/addons/gdUnit3/src/asserts/GdUnitFileAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitFileAssertImpl.gd
@@ -27,8 +27,8 @@ func starts_with_error_message(expected: String) -> GdUnitFileAssert:
 	_base.starts_with_error_message(expected)
 	return self
 
-func as_error_message(message :String) -> GdUnitFileAssert:
-	_base.as_error_message(message)
+func override_failure_message(message :String) -> GdUnitFileAssert:
+	_base.override_failure_message(message)
 	return self
 
 func _notification(event):

--- a/addons/gdUnit3/src/asserts/GdUnitFileAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitFileAssertImpl.gd
@@ -19,12 +19,12 @@ func report_error(error :String) -> GdUnitFileAssert:
 	return self
 
 # -------- Base Assert wrapping ------------------------------------------------
-func has_error_message(expected: String) -> GdUnitFileAssert:
-	_base.has_error_message(expected)
+func has_failure_message(expected: String) -> GdUnitFileAssert:
+	_base.has_failure_message(expected)
 	return self
 
-func starts_with_error_message(expected: String) -> GdUnitFileAssert:
-	_base.starts_with_error_message(expected)
+func starts_with_failure_message(expected: String) -> GdUnitFileAssert:
+	_base.starts_with_failure_message(expected)
 	return self
 
 func override_failure_message(message :String) -> GdUnitFileAssert:

--- a/addons/gdUnit3/src/asserts/GdUnitFloatAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitFloatAssertImpl.gd
@@ -20,12 +20,12 @@ func report_error(error :String) -> GdUnitFloatAssert:
 	return self
 
 # -------- Base Assert wrapping ------------------------------------------------
-func has_error_message(expected: String) -> GdUnitFloatAssert:
-	_base.has_error_message(expected)
+func has_failure_message(expected: String) -> GdUnitFloatAssert:
+	_base.has_failure_message(expected)
 	return self
 
-func starts_with_error_message(expected: String) -> GdUnitFloatAssert:
-	_base.starts_with_error_message(expected)
+func starts_with_failure_message(expected: String) -> GdUnitFloatAssert:
+	_base.starts_with_failure_message(expected)
 	return self
 
 func override_failure_message(message :String) -> GdUnitFloatAssert:

--- a/addons/gdUnit3/src/asserts/GdUnitFloatAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitFloatAssertImpl.gd
@@ -5,7 +5,7 @@ var _base: GdUnitAssert
 
 func _init(caller :Object, current, expect_result :int):
 	_base = GdUnitAssertImpl.new(caller, current, expect_result)
-	if typeof(current) != TYPE_REAL:
+	if current != null and typeof(current) != TYPE_REAL:
 		report_error("GdUnitFloatAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 func __current() -> float:
@@ -28,8 +28,8 @@ func starts_with_error_message(expected: String) -> GdUnitFloatAssert:
 	_base.starts_with_error_message(expected)
 	return self
 
-func as_error_message(message :String) -> GdUnitFloatAssert:
-	_base.as_error_message(message)
+func override_failure_message(message :String) -> GdUnitFloatAssert:
+	_base.override_failure_message(message)
 	return self
 
 func _notification(event):
@@ -38,6 +38,15 @@ func _notification(event):
 			_base.notification(event)
 			_base = null
 #-------------------------------------------------------------------------------
+# Verifies that the current value is null.
+func is_null() -> GdUnitFloatAssert:
+	_base.is_null()
+	return self
+
+# Verifies that the current value is not null.
+func is_not_null() -> GdUnitFloatAssert:
+	_base.is_not_null()
+	return self
 
 # Verifies that the current value is equal to expected one.
 func is_equal(expected :float) -> GdUnitFloatAssert:

--- a/addons/gdUnit3/src/asserts/GdUnitIntAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitIntAssertImpl.gd
@@ -20,12 +20,12 @@ func report_error(error :String) -> GdUnitIntAssert:
 	return self
 
 # -------- Base Assert wrapping ------------------------------------------------
-func has_error_message(expected: String) -> GdUnitIntAssert:
-	_base.has_error_message(expected)
+func has_failure_message(expected: String) -> GdUnitIntAssert:
+	_base.has_failure_message(expected)
 	return self
 
-func starts_with_error_message(expected: String) -> GdUnitIntAssert:
-	_base.starts_with_error_message(expected)
+func starts_with_failure_message(expected: String) -> GdUnitIntAssert:
+	_base.starts_with_failure_message(expected)
 	return self
 
 func override_failure_message(message :String) -> GdUnitIntAssert:

--- a/addons/gdUnit3/src/asserts/GdUnitIntAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitIntAssertImpl.gd
@@ -5,7 +5,7 @@ var _base: GdUnitAssert
 
 func _init(caller :Object, current, expect_result :int = EXPECT_SUCCESS):
 	_base = GdUnitAssertImpl.new(caller, current, expect_result)
-	if typeof(current) != TYPE_INT:
+	if current != null and typeof(current) != TYPE_INT:
 		report_error("GdUnitIntAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 func __current() -> int:
@@ -28,8 +28,8 @@ func starts_with_error_message(expected: String) -> GdUnitIntAssert:
 	_base.starts_with_error_message(expected)
 	return self
 
-func as_error_message(message :String) -> GdUnitIntAssert:
-	_base.as_error_message(message)
+func override_failure_message(message :String) -> GdUnitIntAssert:
+	_base.override_failure_message(message)
 	return self
 
 func _notification(event):
@@ -38,6 +38,15 @@ func _notification(event):
 			_base.notification(event)
 			_base = null
 #-------------------------------------------------------------------------------
+# Verifies that the current value is null.
+func is_null() -> GdUnitIntAssert:
+	_base.is_null()
+	return self
+
+# Verifies that the current value is not null.
+func is_not_null() -> GdUnitIntAssert:
+	_base.is_not_null()
+	return self
 
 # Verifies that the current value is equal to expected one.
 func is_equal(expected :int) -> GdUnitIntAssert:

--- a/addons/gdUnit3/src/asserts/GdUnitObjectAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitObjectAssertImpl.gd
@@ -20,12 +20,12 @@ func report_error(error :String) -> GdUnitObjectAssert:
 	return self
 
 # -------- Base Assert wrapping ------------------------------------------------
-func has_error_message(expected: String) -> GdUnitObjectAssert:
-	_base.has_error_message(expected)
+func has_failure_message(expected: String) -> GdUnitObjectAssert:
+	_base.has_failure_message(expected)
 	return self
 	
-func starts_with_error_message(expected: String) -> GdUnitObjectAssert:
-	_base.starts_with_error_message(expected)
+func starts_with_failure_message(expected: String) -> GdUnitObjectAssert:
+	_base.starts_with_failure_message(expected)
 	return self
 
 func override_failure_message(message :String) -> GdUnitObjectAssert:

--- a/addons/gdUnit3/src/asserts/GdUnitObjectAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitObjectAssertImpl.gd
@@ -28,8 +28,8 @@ func starts_with_error_message(expected: String) -> GdUnitObjectAssert:
 	_base.starts_with_error_message(expected)
 	return self
 
-func as_error_message(message :String) -> GdUnitObjectAssert:
-	_base.as_error_message(message)
+func override_failure_message(message :String) -> GdUnitObjectAssert:
+	_base.override_failure_message(message)
 	return self
 
 func _notification(event):

--- a/addons/gdUnit3/src/asserts/GdUnitResultAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitResultAssertImpl.gd
@@ -28,8 +28,8 @@ func starts_with_error_message(expected: String) -> GdUnitResultAssert:
 	_base.starts_with_error_message(expected)
 	return self
 
-func as_error_message(message :String) -> GdUnitResultAssert:
-	_base.as_error_message(message)
+func override_failure_message(message :String) -> GdUnitResultAssert:
+	_base.override_failure_message(message)
 	return self
 
 func _notification(event):

--- a/addons/gdUnit3/src/asserts/GdUnitResultAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitResultAssertImpl.gd
@@ -20,12 +20,12 @@ func report_error(error :String) -> GdUnitResultAssert:
 	return self
 
 # -------- Base Assert wrapping ------------------------------------------------
-func has_error_message(expected: String) -> GdUnitResultAssert:
-	_base.has_error_message(expected)
+func has_failure_message(expected: String) -> GdUnitResultAssert:
+	_base.has_failure_message(expected)
 	return self
 	
-func starts_with_error_message(expected: String) -> GdUnitResultAssert:
-	_base.starts_with_error_message(expected)
+func starts_with_failure_message(expected: String) -> GdUnitResultAssert:
+	_base.starts_with_failure_message(expected)
 	return self
 
 func override_failure_message(message :String) -> GdUnitResultAssert:

--- a/addons/gdUnit3/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitStringAssertImpl.gd
@@ -5,7 +5,7 @@ var _base :GdUnitAssert
 
 func _init(caller :Object, current, expect_result :int):
 	_base = GdUnitAssertImpl.new(caller, current, expect_result)
-	if typeof(current) != TYPE_STRING:
+	if current != null and typeof(current) != TYPE_STRING:
 		report_error("GdUnitStringAssert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 func __current() -> String:
@@ -26,16 +26,12 @@ func has_error_message(expected: String) -> GdUnitStringAssert:
 	_base.has_error_message(expected)
 	return self
 
-func as_error_message(message :String) -> GdUnitStringAssert:
-	_base.as_error_message(message)
+func override_failure_message(message :String) -> GdUnitStringAssert:
+	_base.override_failure_message(message)
 	return self
 
 func starts_with_error_message(expected: String) -> GdUnitStringAssert:
 	_base.starts_with_error_message(expected)
-	return self
-
-func with_error_info(message :String) -> GdUnitStringAssert:
-	_base.with_error_info(message)
 	return self
 
 func _notification(event):
@@ -44,6 +40,16 @@ func _notification(event):
 			_base.notification(event)
 			_base = null
 #-------------------------------------------------------------------------------
+# Verifies that the current value is null.
+func is_null() -> GdUnitStringAssert:
+	_base.is_null()
+	return self
+
+# Verifies that the current value is not null.
+func is_not_null() -> GdUnitStringAssert:
+	_base.is_not_null()
+	return self
+
 func is_equal(expected) -> GdUnitStringAssert:
 	var current := __current()
 	if not GdObjects.equals(current, expected):

--- a/addons/gdUnit3/src/asserts/GdUnitStringAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitStringAssertImpl.gd
@@ -22,16 +22,16 @@ func report_error(error :String) -> GdUnitStringAssert:
 	return self
 
 # -------- Base Assert overloadings  -------------------------------------------
-func has_error_message(expected: String) -> GdUnitStringAssert:
-	_base.has_error_message(expected)
+func has_failure_message(expected: String) -> GdUnitStringAssert:
+	_base.has_failure_message(expected)
 	return self
 
 func override_failure_message(message :String) -> GdUnitStringAssert:
 	_base.override_failure_message(message)
 	return self
 
-func starts_with_error_message(expected: String) -> GdUnitStringAssert:
-	_base.starts_with_error_message(expected)
+func starts_with_failure_message(expected: String) -> GdUnitStringAssert:
+	_base.starts_with_failure_message(expected)
 	return self
 
 func _notification(event):

--- a/addons/gdUnit3/src/asserts/GdUnitVector2AssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitVector2AssertImpl.gd
@@ -5,7 +5,7 @@ var _base: GdUnitAssert
 
 func _init(caller :Object, current, expect_result :int):
 	_base = GdUnitAssertImpl.new(caller, current, expect_result)
-	if typeof(current) != TYPE_VECTOR2:
+	if current != null and typeof(current) != TYPE_VECTOR2:
 		report_error("GdUnitVector2Assert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 func __current() -> Vector2:
@@ -28,8 +28,8 @@ func starts_with_error_message(expected: String) -> GdUnitVector2Assert:
 	_base.starts_with_error_message(expected)
 	return self
 
-func as_error_message(message :String) -> GdUnitVector2Assert:
-	_base.as_error_message(message)
+func override_failure_message(message :String) -> GdUnitVector2Assert:
+	_base.override_failure_message(message)
 	return self
 
 func _notification(event):
@@ -38,6 +38,15 @@ func _notification(event):
 			_base.notification(event)
 			_base = null
 #-------------------------------------------------------------------------------
+# Verifies that the current value is null.
+func is_null() -> GdUnitVector2Assert:
+	_base.is_null()
+	return self
+
+# Verifies that the current value is not null.
+func is_not_null() -> GdUnitVector2Assert:
+	_base.is_not_null()
+	return self
 
 # Verifies that the current value is equal to expected one.
 func is_equal(expected :Vector2) -> GdUnitVector2Assert:

--- a/addons/gdUnit3/src/asserts/GdUnitVector2AssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitVector2AssertImpl.gd
@@ -20,12 +20,12 @@ func report_error(error :String) -> GdUnitVector2Assert:
 	return self
 
 # -------- Base Assert wrapping ------------------------------------------------
-func has_error_message(expected: String) -> GdUnitVector2Assert:
-	_base.has_error_message(expected)
+func has_failure_message(expected: String) -> GdUnitVector2Assert:
+	_base.has_failure_message(expected)
 	return self
 
-func starts_with_error_message(expected: String) -> GdUnitVector2Assert:
-	_base.starts_with_error_message(expected)
+func starts_with_failure_message(expected: String) -> GdUnitVector2Assert:
+	_base.starts_with_failure_message(expected)
 	return self
 
 func override_failure_message(message :String) -> GdUnitVector2Assert:

--- a/addons/gdUnit3/src/asserts/GdUnitVector3AssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitVector3AssertImpl.gd
@@ -20,12 +20,12 @@ func report_error(error :String) -> GdUnitVector3Assert:
 	return self
 
 # -------- Base Assert wrapping ------------------------------------------------
-func has_error_message(expected: String) -> GdUnitVector3Assert:
-	_base.has_error_message(expected)
+func has_failure_message(expected: String) -> GdUnitVector3Assert:
+	_base.has_failure_message(expected)
 	return self
 
-func starts_with_error_message(expected: String) -> GdUnitVector3Assert:
-	_base.starts_with_error_message(expected)
+func starts_with_failure_message(expected: String) -> GdUnitVector3Assert:
+	_base.starts_with_failure_message(expected)
 	return self
 
 func override_failure_message(message :String) -> GdUnitVector3Assert:

--- a/addons/gdUnit3/src/asserts/GdUnitVector3AssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitVector3AssertImpl.gd
@@ -5,7 +5,7 @@ var _base: GdUnitAssert
 
 func _init(caller :Object, current, expect_result :int):
 	_base = GdUnitAssertImpl.new(caller, current, expect_result)
-	if typeof(current) != TYPE_VECTOR3:
+	if current != null and typeof(current) != TYPE_VECTOR3:
 		report_error("GdUnitVector3Assert inital error, unexpected type <%s>" % GdObjects.typeof_as_string(current))
 
 func __current() -> Vector3:
@@ -28,8 +28,8 @@ func starts_with_error_message(expected: String) -> GdUnitVector3Assert:
 	_base.starts_with_error_message(expected)
 	return self
 
-func as_error_message(message :String) -> GdUnitVector3Assert:
-	_base.as_error_message(message)
+func override_failure_message(message :String) -> GdUnitVector3Assert:
+	_base.override_failure_message(message)
 	return self
 
 func _notification(event):
@@ -38,6 +38,15 @@ func _notification(event):
 			_base.notification(event)
 			_base = null
 #-------------------------------------------------------------------------------
+# Verifies that the current value is null.
+func is_null() -> GdUnitVector3Assert:
+	_base.is_null()
+	return self
+
+# Verifies that the current value is not null.
+func is_not_null() -> GdUnitVector3Assert:
+	_base.is_not_null()
+	return self
 
 # Verifies that the current value is equal to expected one.
 func is_equal(expected :Vector3) -> GdUnitVector3Assert:

--- a/addons/gdUnit3/test/GdUnitTestCaseTimeoutTest.gd
+++ b/addons/gdUnit3/test/GdUnitTestCaseTimeoutTest.gd
@@ -47,7 +47,7 @@ func test_timeout_2s(timeout=2000):
 	prints("B", "2s")
 	yield(get_tree().create_timer(1.0), "timeout")
 	# this line should not reach if timeout aborts the test case after 2s
-	assert_bool(true).as_error_message("The test case must be interupted by a timeout after 2s").is_false()
+	assert_bool(true).override_failure_message("The test case must be interupted by a timeout after 2s").is_false()
 	prints("B", "3s")
 	prints("B", "end")
 
@@ -63,7 +63,7 @@ func test_timeout_4s(timeout=4000):
 	prints("C", "3s")
 	yield(get_tree().create_timer(4.0), "timeout")
 	# this line should not reach if timeout aborts the test case after 4s
-	assert_bool(true).as_error_message("The test case must be interupted by a timeout after 4s").is_false()
+	assert_bool(true).override_failure_message("The test case must be interupted by a timeout after 4s").is_false()
 	prints("C", "7s")
 	prints("C", "end")
 
@@ -73,7 +73,7 @@ func test_timeout_single_yield_wait(timeout=3000):
 	yield(get_tree().create_timer(6.0), "timeout")
 	prints("D", "6s")
 	# this line should not reach if timeout aborts the test case after 3s
-	assert_bool(true).as_error_message("The test case must be interupted by a timeout after 3s").is_false()
+	assert_bool(true).override_failure_message("The test case must be interupted by a timeout after 3s").is_false()
 	prints("D", "end test test_timeout")
 
 func test_timeout_long_running_test_abort(timeout=4000):
@@ -100,7 +100,7 @@ func test_timeout_long_running_test_abort(timeout=4000):
 			break
 	
 	# this line should not reach if timeout aborts the test case after 4s
-	assert_bool(true).as_error_message("The test case must be abort interupted by a timeout 4s").is_false()
+	assert_bool(true).override_failure_message("The test case must be abort interupted by a timeout 4s").is_false()
 	prints("F", "end test test_timeout")
 
 func test_timeout_fuzzer(fuzzer := Fuzzers.rangei(-23, 22), timeout=2000):
@@ -111,5 +111,5 @@ func test_timeout_fuzzer(fuzzer := Fuzzers.rangei(-23, 22), timeout=2000):
 	# we expects the test is interupped after 10 iterations because each test takes 200ms
 	# and the test should not longer run than 2000ms
 	assert_int(fuzzer.iteration_index())\
-		.as_error_message("The test must be interupted after around 10 iterations")\
+		.override_failure_message("The test must be interupted after around 10 iterations")\
 		.is_less_equal(10)

--- a/addons/gdUnit3/test/GdUnitTestSuiteTest.gd
+++ b/addons/gdUnit3/test/GdUnitTestSuiteTest.gd
@@ -15,3 +15,6 @@ func test_assert_that_types() -> void:
 	assert_object(assert_that([])).is_instanceof(GdUnitArrayAssert)
 	assert_object(assert_that({})).is_instanceof(GdUnitDictionaryAssert)
 	assert_object(assert_that(Result.new())).is_instanceof(GdUnitObjectAssert)
+	# all not a built-in types mapped to default GdUnitAssert
+	assert_object(assert_that(Color.red)).is_instanceof(GdUnitAssertImpl)
+	assert_object(assert_that(Plane.PLANE_XY)).is_instanceof(GdUnitAssertImpl)

--- a/addons/gdUnit3/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -197,3 +197,9 @@ func test_extractv_max_args() -> void:
 			tuple("A", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"),
 			tuple("B", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"),
 			tuple("C", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9")])
+
+func test_override_failure_message() -> void:
+	assert_array([], GdUnitAssert.EXPECT_FAIL)\
+		.override_failure_message("Custom failure message")\
+		.is_null()\
+		.has_error_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -10,14 +10,14 @@ func test_is_null():
 	# should fail because the array not null
 	assert_array([], GdUnitAssert.EXPECT_FAIL) \
 		.is_null()\
-		.has_error_message("Expecting: 'Null' but was empty")
+		.has_failure_message("Expecting: 'Null' but was empty")
 
 func test_is_not_null():
 	assert_array([]).is_not_null()
 	# should fail because the array is null
 	assert_array(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_null()\
-		.has_error_message("Expecting: not to be 'Null'")
+		.has_failure_message("Expecting: not to be 'Null'")
 
 func test_is_equal():
 	assert_array([1, 2, 3, 4, 2, 5]).is_equal([1, 2, 3, 4, 2, 5])
@@ -48,14 +48,14 @@ func test_is_empty():
 	# should fail because the array is not empty it has a size of one
 	assert_array([1], GdUnitAssert.EXPECT_FAIL) \
 		.is_empty()\
-		.has_error_message("Expecting:\n must be empty but was\n 1")
+		.has_failure_message("Expecting:\n must be empty but was\n 1")
 
 func test_is_not_empty():
 	assert_array([1]).is_not_empty()
 	# should fail because the array is empty
 	assert_array([], GdUnitAssert.EXPECT_FAIL) \
 		.is_not_empty()\
-		.has_error_message("Expecting:\n must not be empty")
+		.has_failure_message("Expecting:\n must not be empty")
 
 func test_has_size():
 	assert_array([1, 2, 3, 4, 5]).has_size(5)
@@ -63,14 +63,14 @@ func test_has_size():
 	# should fail because the array has a size of 5
 	assert_array([1, 2, 3, 4, 5], GdUnitAssert.EXPECT_FAIL) \
 		.has_size(4)\
-		.has_error_message("Expecting size:\n '4'\n but was\n '5'")
+		.has_failure_message("Expecting size:\n '4'\n but was\n '5'")
 
 func test_contains():
 	assert_array([1, 2, 3, 4, 5]).contains([5, 2])
 	# should fail because the array not contains 7 and 6
 	assert_array([1, 2, 3, 4, 5], GdUnitAssert.EXPECT_FAIL) \
 		.contains([2, 7, 6])\
-		.has_error_message("Expecting:\n 1\n2\n3\n4\n5\n do contains\n 2\n7\n6\nbut could not find elements:\n 7\n6")
+		.has_failure_message("Expecting:\n 1\n2\n3\n4\n5\n do contains\n 2\n7\n6\nbut could not find elements:\n 7\n6")
 
 func test_contains_exactly():
 	assert_array([1, 2, 3, 4, 5]).contains_exactly([1, 2, 3, 4, 5])
@@ -82,7 +82,7 @@ func test_contains_exactly():
  '2' vs '4'"""
 	assert_array([1, 2, 3, 4, 5], GdUnitAssert.EXPECT_FAIL) \
 		.contains_exactly([1, 4, 3, 2, 5])\
-		.has_error_message(expected_error_message)
+		.has_failure_message(expected_error_message)
 
 func test_fluent():
 	assert_array([])\
@@ -94,13 +94,13 @@ func test_fluent():
 
 func test_must_fail_has_invlalid_type():
 	assert_array(1, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitArrayAssert inital error, unexpected type <int>")
+		.has_failure_message("GdUnitArrayAssert inital error, unexpected type <int>")
 	assert_array(1.3, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitArrayAssert inital error, unexpected type <float>")
+		.has_failure_message("GdUnitArrayAssert inital error, unexpected type <float>")
 	assert_array(true, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitArrayAssert inital error, unexpected type <bool>")
+		.has_failure_message("GdUnitArrayAssert inital error, unexpected type <bool>")
 	assert_array(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitArrayAssert inital error, unexpected type <Object>")
+		.has_failure_message("GdUnitArrayAssert inital error, unexpected type <Object>")
 
 func test_extract() -> void:
 	# try to extract on base types
@@ -202,4 +202,4 @@ func test_override_failure_message() -> void:
 	assert_array([], GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
-		.has_error_message("Custom failure message")
+		.has_failure_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitArrayAssertImpl_PoolByteArrayTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitArrayAssertImpl_PoolByteArrayTest.gd
@@ -9,13 +9,13 @@ func test_is_null():
 	assert_array(null).is_null()
 	assert_array(PoolByteArray(), GdUnitAssert.EXPECT_FAIL) \
 		.is_null()\
-		.has_error_message("Expecting: 'Null' but was empty")
+		.has_failure_message("Expecting: 'Null' but was empty")
 
 func test_is_not_null():
 	assert_array(PoolByteArray()).is_not_null()
 	assert_array(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_null()\
-		.has_error_message("Expecting: not to be 'Null'")
+		.has_failure_message("Expecting: not to be 'Null'")
 
 func test_is_equal():
 	assert_array(PoolByteArray([1, 2, 3, 4, 2, 5])).is_equal(PoolByteArray([1, 2, 3, 4, 2, 5]))
@@ -34,13 +34,13 @@ func test_is_not_equal():
 
 func test_must_fail_has_invlalid_type():
 	assert_array(1, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitArrayAssert inital error, unexpected type <int>")
+		.has_failure_message("GdUnitArrayAssert inital error, unexpected type <int>")
 	assert_array(1.3, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitArrayAssert inital error, unexpected type <float>")
+		.has_failure_message("GdUnitArrayAssert inital error, unexpected type <float>")
 	assert_array(true, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitArrayAssert inital error, unexpected type <bool>")
+		.has_failure_message("GdUnitArrayAssert inital error, unexpected type <bool>")
 	assert_array(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitArrayAssert inital error, unexpected type <Object>")
+		.has_failure_message("GdUnitArrayAssert inital error, unexpected type <Object>")
 
 
 
@@ -49,28 +49,28 @@ func test_is_empty():
 	# should fail because the array is not empty
 	assert_array(PoolByteArray([1]), GdUnitAssert.EXPECT_FAIL) \
 		.is_empty()\
-		.has_error_message("Expecting:\n must be empty but was\n 1")
+		.has_failure_message("Expecting:\n must be empty but was\n 1")
 
 func test_is_not_empty():
 	assert_array(PoolByteArray([1])).is_not_empty()
 	# should fail because the array is empty
 	assert_array(PoolByteArray(), GdUnitAssert.EXPECT_FAIL) \
 		.is_not_empty()\
-		.has_error_message("Expecting:\n must not be empty")
+		.has_failure_message("Expecting:\n must not be empty")
 
 func test_has_size():
 	assert_array(PoolByteArray([1, 2, 3, 4, 5])).has_size(5)
 	# should fail because the array has a size of 5
 	assert_array(PoolByteArray([1, 2, 3, 4, 5]), GdUnitAssert.EXPECT_FAIL) \
 		.has_size(4)\
-		.has_error_message("Expecting size:\n '4'\n but was\n '5'")
+		.has_failure_message("Expecting size:\n '4'\n but was\n '5'")
 
 func test_contains():
 	assert_array(PoolByteArray([1, 2, 3, 4, 5])).contains(PoolByteArray([5, 2]))
 	# should fail because the array not contains 7 and 6
 	assert_array(PoolByteArray([1, 2, 3, 4, 5]), GdUnitAssert.EXPECT_FAIL) \
 		.contains(PoolByteArray([2, 7, 6]))\
-		.has_error_message("Expecting:\n 1\n2\n3\n4\n5\n do contains\n 2\n7\n6\nbut could not find elements:\n 7\n6")
+		.has_failure_message("Expecting:\n 1\n2\n3\n4\n5\n do contains\n 2\n7\n6\nbut could not find elements:\n 7\n6")
 
 func test_contains_exactly():
 	assert_array(PoolByteArray([1, 2, 3, 4, 5])).contains_exactly(PoolByteArray([1, 2, 3, 4, 5]))
@@ -82,10 +82,10 @@ func test_contains_exactly():
  '2' vs '4'"""
 	assert_array(PoolByteArray([1, 2, 3, 4, 5]), GdUnitAssert.EXPECT_FAIL) \
 		.contains_exactly(PoolByteArray([1, 4, 3, 2, 5]))\
-		.has_error_message(expected_error_message)
+		.has_failure_message(expected_error_message)
 
 func test_override_failure_message() -> void:
 	assert_array(PoolByteArray([]), GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
-		.has_error_message("Custom failure message")
+		.has_failure_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitArrayAssertImpl_PoolByteArrayTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitArrayAssertImpl_PoolByteArrayTest.gd
@@ -83,4 +83,9 @@ func test_contains_exactly():
 	assert_array(PoolByteArray([1, 2, 3, 4, 5]), GdUnitAssert.EXPECT_FAIL) \
 		.contains_exactly(PoolByteArray([1, 4, 3, 2, 5]))\
 		.has_error_message(expected_error_message)
-		
+
+func test_override_failure_message() -> void:
+	assert_array(PoolByteArray([]), GdUnitAssert.EXPECT_FAIL)\
+		.override_failure_message("Custom failure message")\
+		.is_null()\
+		.has_error_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitAssertImplTest.gd
@@ -25,31 +25,31 @@ func test_is_null():
 	# should fail because the current is not null
 	assert_that(Color.red, GdUnitAssert.EXPECT_FAIL) \
 		.is_null()\
-		.starts_with_error_message("Expecting: 'Null' but was '1,0,0,1'")
+		.starts_with_failure_message("Expecting: 'Null' but was '1,0,0,1'")
 
 func test_is_not_null():
 	assert_that(Color.red).is_not_null()
 	# should fail because the current is null
 	assert_that(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_null()\
-		.has_error_message("Expecting: not to be 'Null'")
+		.has_failure_message("Expecting: not to be 'Null'")
 
 func test_is_equal():
 	assert_that(Color.red).is_equal(Color.red)
 	assert_that(Plane.PLANE_XY).is_equal(Plane.PLANE_XY)
 	assert_that(Color.red, GdUnitAssert.EXPECT_FAIL) \
 		.is_equal(Color.green) \
-		.has_error_message("Expecting:\n '0,1,0,1'\n but was\n '1,0,0,1'")
+		.has_failure_message("Expecting:\n '0,1,0,1'\n but was\n '1,0,0,1'")
 
 func test_is_not_equal():
 	assert_that(Color.red).is_not_equal(Color.green)
 	assert_that(Plane.PLANE_XY).is_not_equal(Plane.PLANE_XZ)
 	assert_that(Color.red, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_equal(Color.red) \
-		.has_error_message("Expecting:\n '1,0,0,1'\n not equal to\n '1,0,0,1'")
+		.has_failure_message("Expecting:\n '1,0,0,1'\n not equal to\n '1,0,0,1'")
 
 func test_override_failure_message() -> void:
 	assert_that(Color.red, GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
-		.has_error_message("Custom failure message")
+		.has_failure_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitAssertImplTest.gd
@@ -19,3 +19,37 @@ func test_get_line_number_multiline():
 	# https://github.com/godotengine/godot/issues/43326
 	assert_int(GdUnitAssertImpl\
 		._get_line_number()).is_equal(20)
+
+func test_is_null():
+	assert_that(null).is_null()
+	# should fail because the current is not null
+	assert_that(Color.red, GdUnitAssert.EXPECT_FAIL) \
+		.is_null()\
+		.starts_with_error_message("Expecting: 'Null' but was '1,0,0,1'")
+
+func test_is_not_null():
+	assert_that(Color.red).is_not_null()
+	# should fail because the current is null
+	assert_that(null, GdUnitAssert.EXPECT_FAIL) \
+		.is_not_null()\
+		.has_error_message("Expecting: not to be 'Null'")
+
+func test_is_equal():
+	assert_that(Color.red).is_equal(Color.red)
+	assert_that(Plane.PLANE_XY).is_equal(Plane.PLANE_XY)
+	assert_that(Color.red, GdUnitAssert.EXPECT_FAIL) \
+		.is_equal(Color.green) \
+		.has_error_message("Expecting:\n '0,1,0,1'\n but was\n '1,0,0,1'")
+
+func test_is_not_equal():
+	assert_that(Color.red).is_not_equal(Color.green)
+	assert_that(Plane.PLANE_XY).is_not_equal(Plane.PLANE_XZ)
+	assert_that(Color.red, GdUnitAssert.EXPECT_FAIL) \
+		.is_not_equal(Color.red) \
+		.has_error_message("Expecting:\n '1,0,0,1'\n not equal to\n '1,0,0,1'")
+
+func test_override_failure_message() -> void:
+	assert_that(Color.red, GdUnitAssert.EXPECT_FAIL)\
+		.override_failure_message("Custom failure message")\
+		.is_null()\
+		.has_error_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitBoolAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitBoolAssertImplTest.gd
@@ -8,56 +8,56 @@ const __source = 'res://addons/gdUnit3/src/asserts/GdUnitBoolAssertImpl.gd'
 func test_is_true():
 	assert_bool(true).is_true()
 	assert_bool(false, GdUnitAssert.EXPECT_FAIL).is_true() \
-		.has_error_message("Expecting: 'True' but is 'False'")
+		.has_failure_message("Expecting: 'True' but is 'False'")
 
 func test_isFalse():
 	assert_bool(false).is_false()
 	assert_bool(true, GdUnitAssert.EXPECT_FAIL).is_false() \
-		.has_error_message("Expecting: 'False' but is 'True'")
+		.has_failure_message("Expecting: 'False' but is 'True'")
 
 func test_is_null():
 	assert_bool(null).is_null()
 	# should fail because the current is not null
 	assert_bool(true, GdUnitAssert.EXPECT_FAIL) \
 		.is_null()\
-		.starts_with_error_message("Expecting: 'Null' but was 'True'")
+		.starts_with_failure_message("Expecting: 'Null' but was 'True'")
 
 func test_is_not_null():
 	assert_bool(true).is_not_null()
 	# should fail because the current is null
 	assert_bool(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_null()\
-		.has_error_message("Expecting: not to be 'Null'")
+		.has_failure_message("Expecting: not to be 'Null'")
 
 func test_is_equal():
 	assert_bool(true).is_equal(true)
 	assert_bool(false).is_equal(false)
 	assert_bool(true, GdUnitAssert.EXPECT_FAIL) \
 		.is_equal(false) \
-		.has_error_message("Expecting:\n 'False'\n but was\n 'True'")
+		.has_failure_message("Expecting:\n 'False'\n but was\n 'True'")
 
 func test_is_not_equal():
 	assert_bool(true).is_not_equal(false)
 	assert_bool(false).is_not_equal(true)
 	assert_bool(true, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_equal(true) \
-		.has_error_message("Expecting:\n 'True'\n not equal to\n 'True'")
+		.has_failure_message("Expecting:\n 'True'\n not equal to\n 'True'")
 
 func test_fluent():
 	assert_bool(true).is_true().is_equal(true).is_not_equal(false)
 
 func test_must_fail_has_invlalid_type():
 	assert_bool(1, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitBoolAssert inital error, unexpected type <int>")
+		.has_failure_message("GdUnitBoolAssert inital error, unexpected type <int>")
 	assert_bool(3.13, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitBoolAssert inital error, unexpected type <float>")
+		.has_failure_message("GdUnitBoolAssert inital error, unexpected type <float>")
 	assert_bool("foo", GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitBoolAssert inital error, unexpected type <String>")
+		.has_failure_message("GdUnitBoolAssert inital error, unexpected type <String>")
 	assert_bool(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitBoolAssert inital error, unexpected type <Object>")
+		.has_failure_message("GdUnitBoolAssert inital error, unexpected type <Object>")
 
 func test_override_failure_message() -> void:
 	assert_bool(true, GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
-		.has_error_message("Custom failure message")
+		.has_failure_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitBoolAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitBoolAssertImplTest.gd
@@ -15,6 +15,20 @@ func test_isFalse():
 	assert_bool(true, GdUnitAssert.EXPECT_FAIL).is_false() \
 		.has_error_message("Expecting: 'False' but is 'True'")
 
+func test_is_null():
+	assert_bool(null).is_null()
+	# should fail because the current is not null
+	assert_bool(true, GdUnitAssert.EXPECT_FAIL) \
+		.is_null()\
+		.starts_with_error_message("Expecting: 'Null' but was 'True'")
+
+func test_is_not_null():
+	assert_bool(true).is_not_null()
+	# should fail because the current is null
+	assert_bool(null, GdUnitAssert.EXPECT_FAIL) \
+		.is_not_null()\
+		.has_error_message("Expecting: not to be 'Null'")
+
 func test_is_equal():
 	assert_bool(true).is_equal(true)
 	assert_bool(false).is_equal(false)
@@ -41,5 +55,9 @@ func test_must_fail_has_invlalid_type():
 		.has_error_message("GdUnitBoolAssert inital error, unexpected type <String>")
 	assert_bool(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
 		.has_error_message("GdUnitBoolAssert inital error, unexpected type <Object>")
-	assert_bool(null, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitBoolAssert inital error, unexpected type <null>")
+
+func test_override_failure_message() -> void:
+	assert_bool(true, GdUnitAssert.EXPECT_FAIL)\
+		.override_failure_message("Custom failure message")\
+		.is_null()\
+		.has_error_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitDictionaryAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitDictionaryAssertImplTest.gd
@@ -7,31 +7,31 @@ const __source = 'res://addons/gdUnit3/src/asserts/GdUnitDictionaryAssertImpl.gd
 
 func test_must_fail_has_invlalid_type():
 	assert_dict(1, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitDictionaryAssert inital error, unexpected type <int>")
+		.has_failure_message("GdUnitDictionaryAssert inital error, unexpected type <int>")
 	assert_dict(1.3, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitDictionaryAssert inital error, unexpected type <float>")
+		.has_failure_message("GdUnitDictionaryAssert inital error, unexpected type <float>")
 	assert_dict(true, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitDictionaryAssert inital error, unexpected type <bool>")
+		.has_failure_message("GdUnitDictionaryAssert inital error, unexpected type <bool>")
 	assert_dict("abc", GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitDictionaryAssert inital error, unexpected type <String>")
+		.has_failure_message("GdUnitDictionaryAssert inital error, unexpected type <String>")
 	assert_dict([], GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitDictionaryAssert inital error, unexpected type <Array>")
+		.has_failure_message("GdUnitDictionaryAssert inital error, unexpected type <Array>")
 	assert_dict(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitDictionaryAssert inital error, unexpected type <Object>")
+		.has_failure_message("GdUnitDictionaryAssert inital error, unexpected type <Object>")
 
 func test_is_null():
 	assert_dict(null).is_null()
 	
 	assert_dict({}, GdUnitAssert.EXPECT_FAIL)\
 		.is_null()\
-		.has_error_message("Expecting: 'Null' but was '{}'")
+		.has_failure_message("Expecting: 'Null' but was '{}'")
 
 func test_is_not_null():
 	assert_dict({}).is_not_null()
 	
 	assert_dict(null, GdUnitAssert.EXPECT_FAIL)\
 		.is_not_null()\
-		.has_error_message("Expecting: not to be 'Null'")
+		.has_failure_message("Expecting: not to be 'Null'")
 		
 
 func test_is_equal():
@@ -131,10 +131,10 @@ func test_contains_keys():
 	
 	assert_dict({1:1, 3:3}, GdUnitAssert.EXPECT_FAIL)\
 		.contains_keys([2])\
-		.has_error_message("Expecting keys:\n 1, 3\n to contains:\n 2\n but can't find key's:\n 2")
+		.has_failure_message("Expecting keys:\n 1, 3\n to contains:\n 2\n but can't find key's:\n 2")
 	assert_dict({1:1, 3:3}, GdUnitAssert.EXPECT_FAIL)\
 		.contains_keys([1, 4])\
-		.has_error_message("Expecting keys:\n 1, 3\n to contains:\n 1, 4\n but can't find key's:\n 4")
+		.has_failure_message("Expecting keys:\n 1, 3\n to contains:\n 1, 4\n but can't find key's:\n 4")
 
 func test_contains_not_keys():
 	assert_dict({}).contains_not_keys([2])
@@ -143,10 +143,10 @@ func test_contains_not_keys():
 	
 	assert_dict({1:1, 2:2, 3:3}, GdUnitAssert.EXPECT_FAIL)\
 		.contains_not_keys([2, 4])\
-		.has_error_message("Expecting keys:\n 1, 2, 3\n do not contains:\n 2, 4\n but contains key's:\n 2")
+		.has_failure_message("Expecting keys:\n 1, 2, 3\n do not contains:\n 2, 4\n but contains key's:\n 2")
 	assert_dict({1:1, 2:2, 3:3}, GdUnitAssert.EXPECT_FAIL)\
 		.contains_not_keys([1, 2, 3, 4])\
-		.has_error_message("Expecting keys:\n 1, 2, 3\n do not contains:\n 1, 2, 3, 4\n but contains key's:\n 1, 2, 3")
+		.has_failure_message("Expecting keys:\n 1, 2, 3\n do not contains:\n 1, 2, 3, 4\n but contains key's:\n 1, 2, 3")
 
 func test_contains_key_value():
 	assert_dict({1:1}).contains_key_value(1, 1)
@@ -154,10 +154,10 @@ func test_contains_key_value():
 	
 	assert_dict({1:1}, GdUnitAssert.EXPECT_FAIL)\
 		.contains_key_value(1, 2)\
-		.has_error_message("Expecting key and value:\n '1' : '2'\n but contains\n '1' : '1'")
+		.has_failure_message("Expecting key and value:\n '1' : '2'\n but contains\n '1' : '1'")
 
 func test_override_failure_message() -> void:
 	assert_dict({1:1}, GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
-		.has_error_message("Custom failure message")
+		.has_failure_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitDictionaryAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitDictionaryAssertImplTest.gd
@@ -155,3 +155,9 @@ func test_contains_key_value():
 	assert_dict({1:1}, GdUnitAssert.EXPECT_FAIL)\
 		.contains_key_value(1, 2)\
 		.has_error_message("Expecting key and value:\n '1' : '2'\n but contains\n '1' : '1'")
+
+func test_override_failure_message() -> void:
+	assert_dict({1:1}, GdUnitAssert.EXPECT_FAIL)\
+		.override_failure_message("Custom failure message")\
+		.is_null()\
+		.has_error_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitFloatAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitFloatAssertImplTest.gd
@@ -5,6 +5,20 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit3/src/asserts/GdUnitFloatAssertImpl.gd'
 
+func test_is_null():
+	assert_float(null).is_null()
+	# should fail because the current is not null
+	assert_float(23.2, GdUnitAssert.EXPECT_FAIL) \
+		.is_null()\
+		.starts_with_error_message("Expecting: 'Null' but was '23.200000'")
+
+func test_is_not_null():
+	assert_float(23.2).is_not_null()
+	# should fail because the current is null
+	assert_float(null, GdUnitAssert.EXPECT_FAIL) \
+		.is_not_null()\
+		.has_error_message("Expecting: not to be 'Null'")
+
 func test_is_equal():
 	assert_float(23.2).is_equal(23.2)
 	# this assertion fails because 23.2 are not equal to 23.4
@@ -132,5 +146,9 @@ func test_must_fail_has_invlalid_type():
 		.has_error_message("GdUnitFloatAssert inital error, unexpected type <String>")
 	assert_float(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
 		.has_error_message("GdUnitFloatAssert inital error, unexpected type <Object>")
-	assert_float(null, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitFloatAssert inital error, unexpected type <null>")
+
+func test_override_failure_message() -> void:
+	assert_float(3.14, GdUnitAssert.EXPECT_FAIL)\
+		.override_failure_message("Custom failure message")\
+		.is_null()\
+		.has_error_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitFloatAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitFloatAssertImplTest.gd
@@ -10,28 +10,28 @@ func test_is_null():
 	# should fail because the current is not null
 	assert_float(23.2, GdUnitAssert.EXPECT_FAIL) \
 		.is_null()\
-		.starts_with_error_message("Expecting: 'Null' but was '23.200000'")
+		.starts_with_failure_message("Expecting: 'Null' but was '23.200000'")
 
 func test_is_not_null():
 	assert_float(23.2).is_not_null()
 	# should fail because the current is null
 	assert_float(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_null()\
-		.has_error_message("Expecting: not to be 'Null'")
+		.has_failure_message("Expecting: not to be 'Null'")
 
 func test_is_equal():
 	assert_float(23.2).is_equal(23.2)
 	# this assertion fails because 23.2 are not equal to 23.4
 	assert_float(23.2, GdUnitAssert.EXPECT_FAIL) \
 		.is_equal(23.4)\
-		.has_error_message("Expecting:\n '23.400000'\n but was\n '23.200000'")
+		.has_failure_message("Expecting:\n '23.400000'\n but was\n '23.200000'")
 
 func test_is_not_equal():
 	assert_float(23.2).is_not_equal(23.4)
 	# this assertion fails because 23.2 are equal to 23.2
 	assert_float(23.2, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_equal(23.2)\
-		.has_error_message("Expecting:\n '23.200000'\n not equal to\n '23.200000'")
+		.has_failure_message("Expecting:\n '23.200000'\n not equal to\n '23.200000'")
 
 func test_is_equal_approx() -> void:
 	assert_float(23.2).is_equal_approx(23.2, 0.01)
@@ -42,10 +42,10 @@ func test_is_equal_approx() -> void:
 	#false test
 	assert_float(23.18, GdUnitAssert.EXPECT_FAIL)\
 		.is_equal_approx(23.2, 0.01)\
-		.has_error_message("Expecting:\n '23.180000'\n in range between\n '23.190000' <> '23.210000'")
+		.has_failure_message("Expecting:\n '23.180000'\n in range between\n '23.190000' <> '23.210000'")
 	assert_float(23.22, GdUnitAssert.EXPECT_FAIL)\
 		.is_equal_approx(23.2, 0.01)\
-		.has_error_message("Expecting:\n '23.220000'\n in range between\n '23.190000' <> '23.210000'")
+		.has_failure_message("Expecting:\n '23.220000'\n in range between\n '23.190000' <> '23.210000'")
 
 func test_is_less():
 	assert_float(23.2).is_less(23.4)
@@ -53,7 +53,7 @@ func test_is_less():
 	# this assertion fails because 23.2 is not less than 23.2
 	assert_float(23.2, GdUnitAssert.EXPECT_FAIL) \
 		.is_less(23.2)\
-		.has_error_message("Expecting to be less than:\n '23.200000' but was '23.200000'")
+		.has_failure_message("Expecting to be less than:\n '23.200000' but was '23.200000'")
 
 func test_is_less_equal():
 	assert_float(23.2).is_less_equal(23.4)
@@ -61,7 +61,7 @@ func test_is_less_equal():
 	# this assertion fails because 23.2 is not less than or equal to 23.1
 	assert_float(23.2, GdUnitAssert.EXPECT_FAIL) \
 		.is_less_equal(23.1)\
-		.has_error_message("Expecting to be less than or equal:\n '23.100000' but was '23.200000'")
+		.has_failure_message("Expecting to be less than or equal:\n '23.100000' but was '23.200000'")
 
 func test_is_greater():
 	assert_float(23.2).is_greater(23.0)
@@ -69,7 +69,7 @@ func test_is_greater():
 	# this assertion fails because 23.2 is not greater than 23.2
 	assert_float(23.2, GdUnitAssert.EXPECT_FAIL) \
 		.is_greater(23.2)\
-		.has_error_message("Expecting to be greater than:\n '23.200000' but was '23.200000'")
+		.has_failure_message("Expecting to be greater than:\n '23.200000' but was '23.200000'")
 
 func test_is_greater_equal():
 	assert_float(23.2).is_greater_equal(20.2)
@@ -77,49 +77,49 @@ func test_is_greater_equal():
 	# this assertion fails because 23.2 is not greater than 23.3
 	assert_float(23.2, GdUnitAssert.EXPECT_FAIL) \
 		.is_greater_equal(23.3)\
-		.has_error_message("Expecting to be greater than or equal:\n '23.300000' but was '23.200000'")
+		.has_failure_message("Expecting to be greater than or equal:\n '23.300000' but was '23.200000'")
 
 func test_is_negative():
 	assert_float(-13.2).is_negative()
 	# this assertion fails because is not negative
 	assert_float(13.2, GdUnitAssert.EXPECT_FAIL) \
 		.is_negative()\
-		.has_error_message("Expecting:\n '13.200000' be negative")
+		.has_failure_message("Expecting:\n '13.200000' be negative")
 
 func test_is_not_negative():
 	assert_float(13.2).is_not_negative()
 	# this assertion fails because is negative
 	assert_float(-13.2, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_negative()\
-		.has_error_message("Expecting:\n '-13.200000' be not negative")
+		.has_failure_message("Expecting:\n '-13.200000' be not negative")
 
 func test_is_zero():
 	assert_float(0.0).is_zero()
 	# this assertion fail because the value is not zero
 	assert_float(0.00001, GdUnitAssert.EXPECT_FAIL) \
 		.is_zero()\
-		.has_error_message("Expecting:\n equal to 0 but is '0.000010'")
+		.has_failure_message("Expecting:\n equal to 0 but is '0.000010'")
 
 func test_is_not_zero():
 	assert_float(0.00001).is_not_zero()
 	# this assertion fail because the value is not zero
 	assert_float(0.000001, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_zero()\
-		.has_error_message("Expecting:\n not equal to 0")
+		.has_failure_message("Expecting:\n not equal to 0")
 
 func test_is_in():
 	assert_float(5.2).is_in([5.1, 5.2, 5.3, 5.4])
 	# this assertion fail because 5.5 is not in [5.1, 5.2, 5.3, 5.4]
 	assert_float(5.5, GdUnitAssert.EXPECT_FAIL) \
 		.is_in([5.1, 5.2, 5.3, 5.4])\
-		.has_error_message("Expecting:\n '5.500000'\n is in\n '[5.1, 5.2, 5.3, 5.4]'")
+		.has_failure_message("Expecting:\n '5.500000'\n is in\n '[5.1, 5.2, 5.3, 5.4]'")
 
 func test_is_not_in():
 	assert_float(5.2).is_not_in([5.1, 5.3, 5.4])
 	# this assertion fail because 5.2 is not in [5.1, 5.2, 5.3, 5.4]
 	assert_float(5.2, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_in([5.1, 5.2, 5.3, 5.4])\
-		.has_error_message("Expecting:\n '5.200000'\n is not in\n '[5.1, 5.2, 5.3, 5.4]'")
+		.has_failure_message("Expecting:\n '5.200000'\n is not in\n '[5.1, 5.2, 5.3, 5.4]'")
 
 func test_is_between():
 	assert_float(-20.0).is_between(-20.0, 20.9)
@@ -129,26 +129,26 @@ func test_is_between():
 func test_is_between_must_fail():
 	assert_float(-10.0, GdUnitAssert.EXPECT_FAIL) \
 		.is_between(-9.0, 0.0) \
-		.has_error_message("Expecting:\n '-10.000000'\n in range between\n '-9.000000' <> '0.000000'")
+		.has_failure_message("Expecting:\n '-10.000000'\n in range between\n '-9.000000' <> '0.000000'")
 	assert_float(0.0, GdUnitAssert.EXPECT_FAIL) \
 		.is_between(1, 10) \
-		.has_error_message("Expecting:\n '0.000000'\n in range between\n '1.000000' <> '10.000000'")
+		.has_failure_message("Expecting:\n '0.000000'\n in range between\n '1.000000' <> '10.000000'")
 	assert_float(10.0, GdUnitAssert.EXPECT_FAIL) \
 		.is_between(11, 21) \
-		.has_error_message("Expecting:\n '10.000000'\n in range between\n '11.000000' <> '21.000000'")
+		.has_failure_message("Expecting:\n '10.000000'\n in range between\n '11.000000' <> '21.000000'")
 
 func test_must_fail_has_invlalid_type():
 	assert_float(1, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitFloatAssert inital error, unexpected type <int>")
+		.has_failure_message("GdUnitFloatAssert inital error, unexpected type <int>")
 	assert_float(true, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitFloatAssert inital error, unexpected type <bool>")
+		.has_failure_message("GdUnitFloatAssert inital error, unexpected type <bool>")
 	assert_float("foo", GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitFloatAssert inital error, unexpected type <String>")
+		.has_failure_message("GdUnitFloatAssert inital error, unexpected type <String>")
 	assert_float(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitFloatAssert inital error, unexpected type <Object>")
+		.has_failure_message("GdUnitFloatAssert inital error, unexpected type <Object>")
 
 func test_override_failure_message() -> void:
 	assert_float(3.14, GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
-		.has_error_message("Custom failure message")
+		.has_failure_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitIntAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitIntAssertImplTest.gd
@@ -10,28 +10,28 @@ func test_is_null():
 	# should fail because the current is not null
 	assert_int(23, GdUnitAssert.EXPECT_FAIL) \
 		.is_null()\
-		.starts_with_error_message("Expecting: 'Null' but was '23'")
+		.starts_with_failure_message("Expecting: 'Null' but was '23'")
 
 func test_is_not_null():
 	assert_int(23).is_not_null()
 	# should fail because the current is null
 	assert_int(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_null()\
-		.has_error_message("Expecting: not to be 'Null'")
+		.has_failure_message("Expecting: not to be 'Null'")
 
 func test_is_equal():
 	assert_int(23).is_equal(23)
 	# this assertion fails because 23 are not equal to 42
 	assert_int(23, GdUnitAssert.EXPECT_FAIL) \
 		.is_equal(42)\
-		.has_error_message("Expecting:\n '42'\n but was\n '23'")
+		.has_failure_message("Expecting:\n '42'\n but was\n '23'")
 
 func test_is_not_equal():
 	assert_int(23).is_not_equal(42)
 	# this assertion fails because 23 are equal to 23 
 	assert_int(23, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_equal(23)\
-		.has_error_message("Expecting:\n '23'\n not equal to\n '23'")
+		.has_failure_message("Expecting:\n '23'\n not equal to\n '23'")
 
 
 func test_is_less():
@@ -40,7 +40,7 @@ func test_is_less():
 	# this assertion fails because 23 is not less than 23
 	assert_int(23, GdUnitAssert.EXPECT_FAIL) \
 		.is_less(23)\
-		.has_error_message("Expecting to be less than:\n '23' but was '23'")
+		.has_failure_message("Expecting to be less than:\n '23' but was '23'")
 
 func test_is_less_equal():
 	assert_int(23).is_less_equal(42)
@@ -48,7 +48,7 @@ func test_is_less_equal():
 	# this assertion fails because 23 is not less than or equal to 22
 	assert_int(23, GdUnitAssert.EXPECT_FAIL) \
 		.is_less_equal(22)\
-		.has_error_message("Expecting to be less than or equal:\n '22' but was '23'")
+		.has_failure_message("Expecting to be less than or equal:\n '22' but was '23'")
 
 func test_is_greater():
 	assert_int(23).is_greater(20)
@@ -56,7 +56,7 @@ func test_is_greater():
 	# this assertion fails because 23 is not greater than 23
 	assert_int(23, GdUnitAssert.EXPECT_FAIL) \
 		.is_greater(23)\
-		.has_error_message("Expecting to be greater than:\n '23' but was '23'")
+		.has_failure_message("Expecting to be greater than:\n '23' but was '23'")
 
 func test_is_greater_equal():
 	assert_int(23).is_greater_equal(20)
@@ -64,7 +64,7 @@ func test_is_greater_equal():
 	# this assertion fails because 23 is not greater than 23
 	assert_int(23, GdUnitAssert.EXPECT_FAIL) \
 		.is_greater_equal(24)\
-		.has_error_message("Expecting to be greater than or equal:\n '24' but was '23'")
+		.has_failure_message("Expecting to be greater than or equal:\n '24' but was '23'")
 
 func _test_is_even_fuzz(fuzzer = Fuzzers.even(-9223372036854775807, 9223372036854775807)):
 	assert_int(fuzzer.next_value()).is_even()
@@ -73,53 +73,53 @@ func test_is_even():
 	assert_int(12).is_even()
 	assert_int(13, GdUnitAssert.EXPECT_FAIL) \
 		.is_even()\
-		.has_error_message("Expecting:\n '13' must be even")
+		.has_failure_message("Expecting:\n '13' must be even")
 
 func test_is_odd():
 	assert_int(13).is_odd()
 	assert_int(12, GdUnitAssert.EXPECT_FAIL) \
 		.is_odd()\
-		.has_error_message("Expecting:\n '12' must be odd")
+		.has_failure_message("Expecting:\n '12' must be odd")
 
 func test_is_negative():
 	assert_int(-13).is_negative()
 	assert_int(13, GdUnitAssert.EXPECT_FAIL) \
 		.is_negative()\
-		.has_error_message("Expecting:\n '13' be negative")
+		.has_failure_message("Expecting:\n '13' be negative")
 
 func test_is_not_negative():
 	assert_int(13).is_not_negative()
 	assert_int(-13, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_negative()\
-		.has_error_message("Expecting:\n '-13' be not negative")
+		.has_failure_message("Expecting:\n '-13' be not negative")
 
 func test_is_zero():
 	assert_int(0).is_zero()
 	# this assertion fail because the value is not zero
 	assert_int(1, GdUnitAssert.EXPECT_FAIL) \
 		.is_zero()\
-		.has_error_message("Expecting:\n equal to 0 but is '1'")
+		.has_failure_message("Expecting:\n equal to 0 but is '1'")
 
 func test_is_not_zero():
 	assert_int(1).is_not_zero()
 	# this assertion fail because the value is not zero
 	assert_int(0, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_zero()\
-		.has_error_message("Expecting:\n not equal to 0")
+		.has_failure_message("Expecting:\n not equal to 0")
 
 func test_is_in():
 	assert_int(5).is_in([3, 4, 5, 6])
 	# this assertion fail because 7 is not in [3, 4, 5, 6]
 	assert_int(7, GdUnitAssert.EXPECT_FAIL) \
 		.is_in([3, 4, 5, 6])\
-		.has_error_message("Expecting:\n '7'\n is in\n '[3, 4, 5, 6]'")
+		.has_failure_message("Expecting:\n '7'\n is in\n '[3, 4, 5, 6]'")
 
 func test_is_not_in():
 	assert_int(5).is_not_in([3, 4, 6, 7])
 	# this assertion fail because 7 is not in [3, 4, 5, 6]
 	assert_int(5, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_in([3, 4, 5, 6])\
-		.has_error_message("Expecting:\n '5'\n is not in\n '[3, 4, 5, 6]'")
+		.has_failure_message("Expecting:\n '5'\n is not in\n '[3, 4, 5, 6]'")
 
 func test_is_between(fuzzer = Fuzzers.rangei(-20, 20)):
 	var value = fuzzer.next_value() as int
@@ -128,26 +128,26 @@ func test_is_between(fuzzer = Fuzzers.rangei(-20, 20)):
 func test_is_between_must_fail():
 	assert_int(-10, GdUnitAssert.EXPECT_FAIL) \
 		.is_between(-9, 0) \
-		.has_error_message("Expecting:\n '-10'\n in range between\n '-9' <> '0'")
+		.has_failure_message("Expecting:\n '-10'\n in range between\n '-9' <> '0'")
 	assert_int(0, GdUnitAssert.EXPECT_FAIL) \
 		.is_between(1, 10) \
-		.has_error_message("Expecting:\n '0'\n in range between\n '1' <> '10'")
+		.has_failure_message("Expecting:\n '0'\n in range between\n '1' <> '10'")
 	assert_int(10, GdUnitAssert.EXPECT_FAIL) \
 		.is_between(11, 21) \
-		.has_error_message("Expecting:\n '10'\n in range between\n '11' <> '21'")
+		.has_failure_message("Expecting:\n '10'\n in range between\n '11' <> '21'")
 
 func test_must_fail_has_invlalid_type():
 	assert_int(3.3, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitIntAssert inital error, unexpected type <float>")
+		.has_failure_message("GdUnitIntAssert inital error, unexpected type <float>")
 	assert_int(true, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitIntAssert inital error, unexpected type <bool>")
+		.has_failure_message("GdUnitIntAssert inital error, unexpected type <bool>")
 	assert_int("foo", GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitIntAssert inital error, unexpected type <String>")
+		.has_failure_message("GdUnitIntAssert inital error, unexpected type <String>")
 	assert_int(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitIntAssert inital error, unexpected type <Object>")
+		.has_failure_message("GdUnitIntAssert inital error, unexpected type <Object>")
 
 func test_override_failure_message() -> void:
 	assert_int(314, GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
-		.has_error_message("Custom failure message")
+		.has_failure_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitIntAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitIntAssertImplTest.gd
@@ -5,14 +5,19 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit3/src/asserts/GdUnitIntAssertImpl.gd'
 
+func test_is_null():
+	assert_int(null).is_null()
+	# should fail because the current is not null
+	assert_int(23, GdUnitAssert.EXPECT_FAIL) \
+		.is_null()\
+		.starts_with_error_message("Expecting: 'Null' but was '23'")
 
-func _test_is_equal_f(fuzzer = Fuzzers.random_rangei(-9223372036854775807, 9223372036854775807)):
-	var value := fuzzer.next_value() as int
-	assert_int(value).is_equal(value)
-
-func _test_is_not_equal_f(fuzzer = Fuzzers.random_rangei(-9223372036854775807, 9223372036854775807)):
-	var value := fuzzer.next_value() as int
-	assert_int(value).is_not_equal(value+1)
+func test_is_not_null():
+	assert_int(23).is_not_null()
+	# should fail because the current is null
+	assert_int(null, GdUnitAssert.EXPECT_FAIL) \
+		.is_not_null()\
+		.has_error_message("Expecting: not to be 'Null'")
 
 func test_is_equal():
 	assert_int(23).is_equal(23)
@@ -37,7 +42,6 @@ func test_is_less():
 		.is_less(23)\
 		.has_error_message("Expecting to be less than:\n '23' but was '23'")
 
-
 func test_is_less_equal():
 	assert_int(23).is_less_equal(42)
 	assert_int(23).is_less_equal(23)
@@ -61,8 +65,6 @@ func test_is_greater_equal():
 	assert_int(23, GdUnitAssert.EXPECT_FAIL) \
 		.is_greater_equal(24)\
 		.has_error_message("Expecting to be greater than or equal:\n '24' but was '23'")
-
-
 
 func _test_is_even_fuzz(fuzzer = Fuzzers.even(-9223372036854775807, 9223372036854775807)):
 	assert_int(fuzzer.next_value()).is_even()
@@ -143,5 +145,9 @@ func test_must_fail_has_invlalid_type():
 		.has_error_message("GdUnitIntAssert inital error, unexpected type <String>")
 	assert_int(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
 		.has_error_message("GdUnitIntAssert inital error, unexpected type <Object>")
-	assert_int(null, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitIntAssert inital error, unexpected type <null>")
+
+func test_override_failure_message() -> void:
+	assert_int(314, GdUnitAssert.EXPECT_FAIL)\
+		.override_failure_message("Custom failure message")\
+		.is_null()\
+		.has_error_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitObjectAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitObjectAssertImplTest.gd
@@ -30,7 +30,7 @@ func test_is_instanceof():
 	# should fail because the current is not a instance of `Tree`
 	assert_object(auto_free(Path.new()), GdUnitAssert.EXPECT_FAIL)\
 		.is_instanceof(Tree)\
-		.has_error_message("Expected instance of:\n 'Tree'\n But it was 'Path'")
+		.has_failure_message("Expected instance of:\n 'Tree'\n But it was 'Path'")
 
 func test_is_not_instanceof():
 	# engine class test
@@ -44,27 +44,27 @@ func test_is_not_instanceof():
 	# should fail because the current is not a instance of `Tree`
 	assert_object(auto_free(Path.new()), GdUnitAssert.EXPECT_FAIL)\
 		.is_not_instanceof(Node)\
-		.has_error_message("Expected not be a instance of <Node>")
+		.has_failure_message("Expected not be a instance of <Node>")
 
 func test_is_not_instanceof_on_null_value():
 	assert_object(null, GdUnitAssert.EXPECT_FAIL)\
 		.is_not_null()\
 		.is_instanceof(Node)\
-		.has_error_message("Expected instance of:\n 'Node'\n But it was 'Null'")
+		.has_failure_message("Expected instance of:\n 'Node'\n But it was 'Null'")
 
 func test_is_null():
 	assert_object(null).is_null()
 	# should fail because the current is not null
 	assert_object(auto_free(Node.new()), GdUnitAssert.EXPECT_FAIL) \
 		.is_null()\
-		.starts_with_error_message("Expecting: 'Null' but was <Node>")
+		.starts_with_failure_message("Expecting: 'Null' but was <Node>")
 
 func test_is_not_null():
 	assert_object(auto_free(Node.new())).is_not_null()
 	# should fail because the current is null
 	assert_object(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_null()\
-		.has_error_message("Expecting: not to be 'Null'")
+		.has_failure_message("Expecting: not to be 'Null'")
 
 func test_is_same():
 	var obj1 = auto_free(Node.new())
@@ -93,16 +93,16 @@ func test_is_not_same():
 
 func test_must_fail_has_invlalid_type():
 	assert_object(1, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitObjectAssert inital error, unexpected type <int>")
+		.has_failure_message("GdUnitObjectAssert inital error, unexpected type <int>")
 	assert_object(1.3, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitObjectAssert inital error, unexpected type <float>")
+		.has_failure_message("GdUnitObjectAssert inital error, unexpected type <float>")
 	assert_object(true, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitObjectAssert inital error, unexpected type <bool>")
+		.has_failure_message("GdUnitObjectAssert inital error, unexpected type <bool>")
 	assert_object("foo", GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitObjectAssert inital error, unexpected type <String>")
+		.has_failure_message("GdUnitObjectAssert inital error, unexpected type <String>")
 
 func test_override_failure_message() -> void:
 	assert_object(auto_free(Node.new()), GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
-		.has_error_message("Custom failure message")
+		.has_failure_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitObjectAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitObjectAssertImplTest.gd
@@ -101,3 +101,8 @@ func test_must_fail_has_invlalid_type():
 	assert_object("foo", GdUnitAssert.EXPECT_FAIL) \
 		.has_error_message("GdUnitObjectAssert inital error, unexpected type <String>")
 
+func test_override_failure_message() -> void:
+	assert_object(auto_free(Node.new()), GdUnitAssert.EXPECT_FAIL)\
+		.override_failure_message("Custom failure message")\
+		.is_null()\
+		.has_error_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitResultAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitResultAssertImplTest.gd
@@ -91,3 +91,9 @@ func test_is_value():
 	assert_result(Result.success(result_value), GdUnitAssert.EXPECT_FAIL) \
 		.is_value("") \
 		.has_error_message("Expecting to contain same value:\n ''\n but was\n <Node>.")
+
+func test_override_failure_message() -> void:
+	assert_result(Result.success(""), GdUnitAssert.EXPECT_FAIL)\
+		.override_failure_message("Custom failure message")\
+		.is_null()\
+		.has_error_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitResultAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitResultAssertImplTest.gd
@@ -10,58 +10,58 @@ func test_is_null():
 	
 	assert_result(Result.success(""), GdUnitAssert.EXPECT_FAIL) \
 		.is_null() \
-		.has_error_message("Expecting: 'Null' but was <Reference>")
+		.has_failure_message("Expecting: 'Null' but was <Reference>")
 
 func test_is_not_null():
 	assert_result(Result.success("")).is_not_null()
 	
 	assert_result(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_null() \
-		.has_error_message("Expecting: not to be 'Null'")
+		.has_failure_message("Expecting: not to be 'Null'")
 
 func test_is_empty():
 	assert_result(Result.empty()).is_empty()
 	
 	assert_result(Result.warn("a warning"), GdUnitAssert.EXPECT_FAIL) \
 		.is_empty() \
-		.has_error_message("Expecting the result must be a EMPTY but was WARNING:\n 'a warning'")
+		.has_failure_message("Expecting the result must be a EMPTY but was WARNING:\n 'a warning'")
 	
 	assert_result(Result.error("a error"), GdUnitAssert.EXPECT_FAIL) \
 		.is_empty() \
-		.has_error_message("Expecting the result must be a EMPTY but was ERROR:\n 'a error'")
+		.has_failure_message("Expecting the result must be a EMPTY but was ERROR:\n 'a error'")
 
 func test_is_success():
 	assert_result(Result.success("")).is_success()
 	
 	assert_result(Result.warn("a warning"), GdUnitAssert.EXPECT_FAIL) \
 		.is_success() \
-		.has_error_message("Expecting the result must be a SUCCESS but was WARNING:\n 'a warning'")
+		.has_failure_message("Expecting the result must be a SUCCESS but was WARNING:\n 'a warning'")
 	
 	assert_result(Result.error("a error"), GdUnitAssert.EXPECT_FAIL) \
 		.is_success() \
-		.has_error_message("Expecting the result must be a SUCCESS but was ERROR:\n 'a error'")
+		.has_failure_message("Expecting the result must be a SUCCESS but was ERROR:\n 'a error'")
 
 func test_is_warning():
 	assert_result(Result.warn("a warning")).is_warning()
 	
 	assert_result(Result.success("value"), GdUnitAssert.EXPECT_FAIL) \
 		.is_warning() \
-		.has_error_message("Expecting the result must be a WARNING but was SUCCESS.")
+		.has_failure_message("Expecting the result must be a WARNING but was SUCCESS.")
 	
 	assert_result(Result.error("a error"), GdUnitAssert.EXPECT_FAIL) \
 		.is_warning() \
-		.has_error_message("Expecting the result must be a WARNING but was ERROR:\n 'a error'")
+		.has_failure_message("Expecting the result must be a WARNING but was ERROR:\n 'a error'")
 
 func test_is_error():
 	assert_result(Result.error("a error")).is_error()
 	
 	assert_result(Result.success(""), GdUnitAssert.EXPECT_FAIL) \
 		.is_error() \
-		.has_error_message("Expecting the result must be a ERROR but was SUCCESS.")
+		.has_failure_message("Expecting the result must be a ERROR but was SUCCESS.")
 	
 	assert_result(Result.warn("a warning"), GdUnitAssert.EXPECT_FAIL) \
 		.is_error() \
-		.has_error_message("Expecting the result must be a ERROR but was WARNING:\n 'a warning'")
+		.has_failure_message("Expecting the result must be a ERROR but was WARNING:\n 'a warning'")
 
 func test_contains_message():
 	assert_result(Result.error("a error")).contains_message("a error")
@@ -69,13 +69,13 @@ func test_contains_message():
 	
 	assert_result(Result.success(""), GdUnitAssert.EXPECT_FAIL) \
 		.contains_message("Error 500") \
-		.has_error_message("Expecting:\n 'Error 500'\n but the Result is a success.")
+		.has_failure_message("Expecting:\n 'Error 500'\n but the Result is a success.")
 	assert_result(Result.warn("Warning xyz!"), GdUnitAssert.EXPECT_FAIL) \
 		.contains_message("Warning aaa!") \
-		.has_error_message("Expecting:\n 'Warning aaa!'\n but was\n 'Warning xyz!'.")
+		.has_failure_message("Expecting:\n 'Warning aaa!'\n but was\n 'Warning xyz!'.")
 	assert_result(Result.error("Error 410"), GdUnitAssert.EXPECT_FAIL) \
 		.contains_message("Error 500") \
-		.has_error_message("Expecting:\n 'Error 500'\n but was\n 'Error 410'.")
+		.has_failure_message("Expecting:\n 'Error 500'\n but was\n 'Error 410'.")
 
 func test_is_value():
 	assert_result(Result.success("")).is_value("")
@@ -84,16 +84,16 @@ func test_is_value():
 	
 	assert_result(Result.success(""), GdUnitAssert.EXPECT_FAIL) \
 		.is_value("abc") \
-		.has_error_message("Expecting to contain same value:\n 'abc'\n but was\n ''.")
+		.has_failure_message("Expecting to contain same value:\n 'abc'\n but was\n ''.")
 	assert_result(Result.success("abc"), GdUnitAssert.EXPECT_FAIL) \
 		.is_value("") \
-		.has_error_message("Expecting to contain same value:\n ''\n but was\n 'abc'.")
+		.has_failure_message("Expecting to contain same value:\n ''\n but was\n 'abc'.")
 	assert_result(Result.success(result_value), GdUnitAssert.EXPECT_FAIL) \
 		.is_value("") \
-		.has_error_message("Expecting to contain same value:\n ''\n but was\n <Node>.")
+		.has_failure_message("Expecting to contain same value:\n ''\n but was\n <Node>.")
 
 func test_override_failure_message() -> void:
 	assert_result(Result.success(""), GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
-		.has_error_message("Custom failure message")
+		.has_failure_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitStringAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitStringAssertImplTest.gd
@@ -10,48 +10,48 @@ func test_is_null():
 	# should fail because the current is not null
 	assert_str("abc", GdUnitAssert.EXPECT_FAIL) \
 		.is_null()\
-		.starts_with_error_message("Expecting: 'Null' but was 'abc'")
+		.starts_with_failure_message("Expecting: 'Null' but was 'abc'")
 
 func test_is_not_null():
 	assert_str("abc").is_not_null()
 	# should fail because the current is null
 	assert_str(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_null()\
-		.has_error_message("Expecting: not to be 'Null'")
+		.has_failure_message("Expecting: not to be 'Null'")
 
 func test_is_equal():
 	assert_str("This is a test message").is_equal("This is a test message")
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.is_equal("This is a test Message") \
-		.has_error_message("Expecting:\n 'This is a test Message'\n but was\n 'This is a test Mmessage'")
+		.has_failure_message("Expecting:\n 'This is a test Message'\n but was\n 'This is a test Mmessage'")
 
 func test_is_equal_ignoring_case():
 	assert_str("This is a test message").is_equal_ignoring_case("This is a test Message")
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.is_equal_ignoring_case("This is a Message") \
-		.has_error_message("Expecting:\n 'This is a Message'\n but was\n 'This is a test Mmessage' (ignoring case)")
+		.has_failure_message("Expecting:\n 'This is a Message'\n but was\n 'This is a test Mmessage' (ignoring case)")
 
 func test_is_not_equal():
 	assert_str("This is a test message").is_not_equal("This is a test Message")
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.is_not_equal("This is a test message")\
-		.has_error_message("Expecting:\n 'This is a test message'\n not equal to\n 'This is a test message'")
+		.has_failure_message("Expecting:\n 'This is a test message'\n not equal to\n 'This is a test message'")
 
 func test_is_not_equal_ignoring_case():
 	assert_str("This is a test message").is_not_equal_ignoring_case("This is a Message")
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.is_not_equal_ignoring_case("This is a test Message")\
-		.has_error_message("Expecting:\n 'This is a test Message'\n not equal to\n 'This is a test message'")
+		.has_failure_message("Expecting:\n 'This is a test Message'\n not equal to\n 'This is a test message'")
 
 func test_is_empty():
 	assert_str("").is_empty()
 	# should fail because the current value is not empty it contains a space
 	assert_str(" ", GdUnitAssert.EXPECT_FAIL)\
 		.is_empty()\
-		.has_error_message("Expecting:\n must be empty but was\n ' '")
+		.has_failure_message("Expecting:\n must be empty but was\n ' '")
 	assert_str("abc", GdUnitAssert.EXPECT_FAIL)\
 		.is_empty()\
-		.has_error_message("Expecting:\n must be empty but was\n 'abc'")
+		.has_failure_message("Expecting:\n must be empty but was\n 'abc'")
 
 func test_is_not_empty():
 	assert_str(" ").is_not_empty()
@@ -60,14 +60,14 @@ func test_is_not_empty():
 	# should fail because current is empty
 	assert_str("", GdUnitAssert.EXPECT_FAIL)\
 		.is_not_empty()\
-		.has_error_message("Expecting:\n must not be empty")
+		.has_failure_message("Expecting:\n must not be empty")
 
 func test_contains():
 	assert_str("This is a test message").contains("a test")
 	# must fail because of camel case difference
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.contains("a Test") \
-		.has_error_message("Expecting:\n 'This is a test message'\n do contains\n 'a Test'")
+		.has_failure_message("Expecting:\n 'This is a test message'\n do contains\n 'a Test'")
 
 func test_not_contains():
 	assert_str("This is a test message").not_contains("a tezt")
@@ -75,7 +75,7 @@ func test_not_contains():
 func test_not_contains_do_fail():
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.not_contains("a test") \
-		.has_error_message("Expecting:\n 'This is a test message'\n not do contain\n 'a test'")
+		.has_failure_message("Expecting:\n 'This is a test message'\n not do contain\n 'a test'")
 
 func test_contains_ignoring_case():
 	assert_str("This is a test message").contains_ignoring_case("a Test")
@@ -83,7 +83,7 @@ func test_contains_ignoring_case():
 func test_contains_ignoring_case_do_fail():
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.contains_ignoring_case("a Tesd") \
-		.has_error_message("Expecting:\n 'This is a test message'\n contains\n 'a Tesd'\n (ignoring case)")
+		.has_failure_message("Expecting:\n 'This is a test message'\n contains\n 'a Tesd'\n (ignoring case)")
 
 func test_not_contains_ignoring_case():
 	assert_str("This is a test message").not_contains_ignoring_case("a Tezt")
@@ -91,7 +91,7 @@ func test_not_contains_ignoring_case():
 func test_not_contains_ignoring_case_do_fail():
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.not_contains_ignoring_case("a Test") \
-		.has_error_message("Expecting:\n 'This is a test message'\n not do contains\n 'a Test'\n (ignoring case)")
+		.has_failure_message("Expecting:\n 'This is a test message'\n not do contains\n 'a Test'\n (ignoring case)")
 
 func test_starts_with():
 	assert_str("This is a test message").starts_with("This is")
@@ -99,13 +99,13 @@ func test_starts_with():
 func test_starts_with_do_fail():
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.starts_with("This iss") \
-		.has_error_message("Expecting:\n 'This is a test message'\n to start with\n 'This iss'")
+		.has_failure_message("Expecting:\n 'This is a test message'\n to start with\n 'This iss'")
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.starts_with("this is") \
-		.has_error_message("Expecting:\n 'This is a test message'\n to start with\n 'this is'")
+		.has_failure_message("Expecting:\n 'This is a test message'\n to start with\n 'this is'")
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.starts_with("test") \
-		.has_error_message("Expecting:\n 'This is a test message'\n to start with\n 'test'")
+		.has_failure_message("Expecting:\n 'This is a test message'\n to start with\n 'test'")
 
 func test_ends_with():
 	assert_str("This is a test message").ends_with("test message")
@@ -113,10 +113,10 @@ func test_ends_with():
 func test_ends_with_do_fail():
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.ends_with("tes message") \
-		.has_error_message("Expecting:\n 'This is a test message'\n to end with\n 'tes message'")
+		.has_failure_message("Expecting:\n 'This is a test message'\n to end with\n 'tes message'")
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.ends_with("a test") \
-		.has_error_message("Expecting:\n 'This is a test message'\n to end with\n 'a test'")
+		.has_failure_message("Expecting:\n 'This is a test message'\n to end with\n 'a test'")
 
 func test_has_lenght():
 	assert_str("This is a test message").has_length(22)
@@ -125,7 +125,7 @@ func test_has_lenght():
 func test_has_lenght_do_fail():
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.has_length(23) \
-		.has_error_message("Expecting size:\n '23' but was '22' in\n 'This is a test message'")
+		.has_failure_message("Expecting size:\n '23' but was '22' in\n 'This is a test message'")
 
 func test_has_lenght_less_than():
 	assert_str("This is a test message").has_length(23, Comparator.LESS_THAN)
@@ -134,7 +134,7 @@ func test_has_lenght_less_than():
 func test_has_lenght_less_than_do_fail():
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.has_length(22, Comparator.LESS_THAN) \
-		.has_error_message("Expecting size to be less than:\n '22' but was '22' in\n 'This is a test message'")
+		.has_failure_message("Expecting size to be less than:\n '22' but was '22' in\n 'This is a test message'")
 
 func test_has_lenght_less_equal():
 	assert_str("This is a test message").has_length(22, Comparator.LESS_EQUAL)
@@ -143,7 +143,7 @@ func test_has_lenght_less_equal():
 func test_has_lenght_less_equal_do_fail():
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.has_length(21, Comparator.LESS_EQUAL) \
-		.has_error_message("Expecting size to be less than or equal:\n '21' but was '22' in\n 'This is a test message'")
+		.has_failure_message("Expecting size to be less than or equal:\n '21' but was '22' in\n 'This is a test message'")
 
 func test_has_lenght_greater_than():
 	assert_str("This is a test message").has_length(21, Comparator.GREATER_THAN)
@@ -151,7 +151,7 @@ func test_has_lenght_greater_than():
 func test_has_lenght_greater_than_do_fail():
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.has_length(22, Comparator.GREATER_THAN) \
-		.has_error_message("Expecting size to be greater than:\n '22' but was '22' in\n 'This is a test message'")
+		.has_failure_message("Expecting size to be greater than:\n '22' but was '22' in\n 'This is a test message'")
 
 func test_has_lenght_greater_equal():
 	assert_str("This is a test message").has_length(21, Comparator.GREATER_EQUAL)
@@ -160,7 +160,7 @@ func test_has_lenght_greater_equal():
 func test_has_lenght_greater_equal_do_fail():
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
 		.has_length(23, Comparator.GREATER_EQUAL) \
-		.has_error_message("Expecting size to be greater than or equal:\n '23' but was '22' in\n 'This is a test message'")
+		.has_failure_message("Expecting size to be greater than or equal:\n '23' but was '22' in\n 'This is a test message'")
 
 func test_fluentable():
 	assert_str("value a").is_not_equal("a")\
@@ -170,16 +170,16 @@ func test_fluentable():
 
 func test_must_fail_has_invlalid_type():
 	assert_str(1, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitStringAssert inital error, unexpected type <int>")
+		.has_failure_message("GdUnitStringAssert inital error, unexpected type <int>")
 	assert_str(1.3, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitStringAssert inital error, unexpected type <float>")
+		.has_failure_message("GdUnitStringAssert inital error, unexpected type <float>")
 	assert_str(true, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitStringAssert inital error, unexpected type <bool>")
+		.has_failure_message("GdUnitStringAssert inital error, unexpected type <bool>")
 	assert_str(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitStringAssert inital error, unexpected type <Object>")
+		.has_failure_message("GdUnitStringAssert inital error, unexpected type <Object>")
 
 func test_override_failure_message() -> void:
 	assert_str("", GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
-		.has_error_message("Custom failure message")
+		.has_failure_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitStringAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitStringAssertImplTest.gd
@@ -5,6 +5,20 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit3/src/asserts/GdUnitStringAssertImpl.gd'
 
+func test_is_null():
+	assert_str(null).is_null()
+	# should fail because the current is not null
+	assert_str("abc", GdUnitAssert.EXPECT_FAIL) \
+		.is_null()\
+		.starts_with_error_message("Expecting: 'Null' but was 'abc'")
+
+func test_is_not_null():
+	assert_str("abc").is_not_null()
+	# should fail because the current is null
+	assert_str(null, GdUnitAssert.EXPECT_FAIL) \
+		.is_not_null()\
+		.has_error_message("Expecting: not to be 'Null'")
+
 func test_is_equal():
 	assert_str("This is a test message").is_equal("This is a test message")
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \
@@ -163,5 +177,9 @@ func test_must_fail_has_invlalid_type():
 		.has_error_message("GdUnitStringAssert inital error, unexpected type <bool>")
 	assert_str(Resource.new(), GdUnitAssert.EXPECT_FAIL) \
 		.has_error_message("GdUnitStringAssert inital error, unexpected type <Object>")
-	assert_str(null, GdUnitAssert.EXPECT_FAIL) \
-		.has_error_message("GdUnitStringAssert inital error, unexpected type <null>")
+
+func test_override_failure_message() -> void:
+	assert_str("", GdUnitAssert.EXPECT_FAIL)\
+		.override_failure_message("Custom failure message")\
+		.is_null()\
+		.has_error_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitVector2AssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitVector2AssertImplTest.gd
@@ -10,14 +10,14 @@ func test_is_null():
 	# should fail because the current is not null
 	assert_vector2(Vector2.ONE, GdUnitAssert.EXPECT_FAIL) \
 		.is_null()\
-		.starts_with_error_message("Expecting: 'Null' but was '(1, 1)'")
+		.starts_with_failure_message("Expecting: 'Null' but was '(1, 1)'")
 
 func test_is_not_null():
 	assert_vector2(Vector2.ONE).is_not_null()
 	# should fail because the current is null
 	assert_vector2(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_null()\
-		.has_error_message("Expecting: not to be 'Null'")
+		.has_failure_message("Expecting: not to be 'Null'")
 
 func test_is_equal() -> void:
 	assert_vector2(Vector2.ONE).is_equal(Vector2.ONE)
@@ -27,7 +27,7 @@ func test_is_equal() -> void:
 	# false test
 	assert_vector2(Vector2.ONE, GdUnitAssert.EXPECT_FAIL)\
 		.is_equal(Vector2(1.2, 1.000001))\
-		.has_error_message("Expecting:\n '(1.2, 1.000001)'\n but was\n '(1, 1)'")
+		.has_failure_message("Expecting:\n '(1.2, 1.000001)'\n but was\n '(1, 1)'")
 
 func test_is_not_equal() -> void:
 	assert_vector2(Vector2.ONE).is_not_equal(Vector2.INF)
@@ -37,7 +37,7 @@ func test_is_not_equal() -> void:
 	# false test
 	assert_vector2(Vector2(1.2, 1.000001), GdUnitAssert.EXPECT_FAIL)\
 		.is_not_equal(Vector2(1.2, 1.000001))\
-		.has_error_message("Expecting:\n '(1.2, 1.000001)'\n not equal to\n '(1.2, 1.000001)'")
+		.has_failure_message("Expecting:\n '(1.2, 1.000001)'\n not equal to\n '(1.2, 1.000001)'")
 
 func test_is_equal_approx() -> void:
 	assert_vector2(Vector2.ONE).is_equal_approx(Vector2.ONE, Vector2(0.004, 0.004))
@@ -47,10 +47,10 @@ func test_is_equal_approx() -> void:
 	# false test
 	assert_vector2(Vector2(1.005, 1), GdUnitAssert.EXPECT_FAIL)\
 		.is_equal_approx(Vector2.ONE, Vector2(0.004, 0.004))\
-		.has_error_message("Expecting:\n '(1.005, 1)'\n in range between\n '(0.996, 0.996)' <> '(1.004, 1.004)'")
+		.has_failure_message("Expecting:\n '(1.005, 1)'\n in range between\n '(0.996, 0.996)' <> '(1.004, 1.004)'")
 	assert_vector2(Vector2(1, 0.995), GdUnitAssert.EXPECT_FAIL)\
 		.is_equal_approx(Vector2.ONE, Vector2(0, 0.004))\
-		.has_error_message("Expecting:\n '(1, 0.995)'\n in range between\n '(1, 0.996)' <> '(1, 1.004)'")
+		.has_failure_message("Expecting:\n '(1, 0.995)'\n in range between\n '(1, 0.996)' <> '(1, 1.004)'")
 
 func test_is_less() -> void:
 	assert_vector2(Vector2.ONE).is_less(Vector2.INF)
@@ -59,10 +59,10 @@ func test_is_less() -> void:
 	# false test
 	assert_vector2(Vector2.ONE, GdUnitAssert.EXPECT_FAIL)\
 		.is_less(Vector2.ONE)\
-		.has_error_message("Expecting to be less than:\n '(1, 1)' but was '(1, 1)'")
+		.has_failure_message("Expecting to be less than:\n '(1, 1)' but was '(1, 1)'")
 	assert_vector2(Vector2(1.2, 1.000001), GdUnitAssert.EXPECT_FAIL)\
 		.is_less(Vector2(1.2, 1.000001))\
-		.has_error_message("Expecting to be less than:\n '(1.2, 1.000001)' but was '(1.2, 1.000001)'")
+		.has_failure_message("Expecting to be less than:\n '(1.2, 1.000001)' but was '(1.2, 1.000001)'")
 
 func test_is_less_equal() -> void:
 	assert_vector2(Vector2.ONE).is_less_equal(Vector2.INF)
@@ -72,10 +72,10 @@ func test_is_less_equal() -> void:
 	# false test
 	assert_vector2(Vector2.ONE, GdUnitAssert.EXPECT_FAIL)\
 		.is_less_equal(Vector2.ZERO)\
-		.has_error_message("Expecting to be less than or equal:\n '(0, 0)' but was '(1, 1)'")
+		.has_failure_message("Expecting to be less than or equal:\n '(0, 0)' but was '(1, 1)'")
 	assert_vector2(Vector2(1.2, 1.000002), GdUnitAssert.EXPECT_FAIL)\
 		.is_less_equal(Vector2(1.2, 1.000001))\
-		.has_error_message("Expecting to be less than or equal:\n '(1.2, 1.000001)' but was '(1.2, 1.000002)'")
+		.has_failure_message("Expecting to be less than or equal:\n '(1.2, 1.000001)' but was '(1.2, 1.000002)'")
 
 
 func test_is_greater() -> void:
@@ -85,10 +85,10 @@ func test_is_greater() -> void:
 	# false test
 	assert_vector2(Vector2.ZERO, GdUnitAssert.EXPECT_FAIL)\
 		.is_greater(Vector2.ONE)\
-		.has_error_message("Expecting to be greater than:\n '(1, 1)' but was '(0, 0)'")
+		.has_failure_message("Expecting to be greater than:\n '(1, 1)' but was '(0, 0)'")
 	assert_vector2(Vector2(1.2, 1.000001), GdUnitAssert.EXPECT_FAIL)\
 		.is_greater(Vector2(1.2, 1.000001))\
-		.has_error_message("Expecting to be greater than:\n '(1.2, 1.000001)' but was '(1.2, 1.000001)'")
+		.has_failure_message("Expecting to be greater than:\n '(1.2, 1.000001)' but was '(1.2, 1.000001)'")
 
 func test_is_greater_equal() -> void:
 	assert_vector2(Vector2.INF).is_greater_equal(Vector2.ONE)
@@ -99,10 +99,10 @@ func test_is_greater_equal() -> void:
 	# false test
 	assert_vector2(Vector2.ZERO, GdUnitAssert.EXPECT_FAIL)\
 		.is_greater_equal(Vector2.ONE)\
-		.has_error_message("Expecting to be greater than or equal:\n '(1, 1)' but was '(0, 0)'")
+		.has_failure_message("Expecting to be greater than or equal:\n '(1, 1)' but was '(0, 0)'")
 	assert_vector2(Vector2(1.2, 1.000002), GdUnitAssert.EXPECT_FAIL)\
 		.is_greater_equal(Vector2(1.2, 1.000003))\
-		.has_error_message("Expecting to be greater than or equal:\n '(1.2, 1.000003)' but was '(1.2, 1.000002)'")
+		.has_failure_message("Expecting to be greater than or equal:\n '(1.2, 1.000003)' but was '(1.2, 1.000002)'")
 
 func test_is_between(fuzzer = Fuzzers.rangev2(Vector2.ZERO, Vector2.ONE)):
 	var value :Vector2 = fuzzer.next_value()
@@ -111,7 +111,7 @@ func test_is_between(fuzzer = Fuzzers.rangev2(Vector2.ZERO, Vector2.ONE)):
 func test_is_between_fail():
 	assert_vector2(Vector2(1, 1.00001), GdUnitAssert.EXPECT_FAIL)\
 		.is_between(Vector2.ZERO, Vector2.ONE)\
-		.has_error_message("Expecting:\n '(1, 1.00001)'\n in range between\n '(0, 0)' <> '(1, 1)'")
+		.has_failure_message("Expecting:\n '(1, 1.00001)'\n in range between\n '(0, 0)' <> '(1, 1)'")
 
 func test_is_not_between(fuzzer = Fuzzers.rangev2(Vector2.ZERO, Vector2.ONE)):
 	var value :Vector2 = fuzzer.next_value()
@@ -120,10 +120,10 @@ func test_is_not_between(fuzzer = Fuzzers.rangev2(Vector2.ZERO, Vector2.ONE)):
 func test_is_not_between_fail():
 	assert_vector2(Vector2.ONE, GdUnitAssert.EXPECT_FAIL)\
 		.is_not_between(Vector2.ZERO, Vector2.ONE)\
-		.has_error_message("Expecting:\n '(1, 1)'\n not in range between\n '(0, 0)' <> '(1, 1)'")
+		.has_failure_message("Expecting:\n '(1, 1)'\n not in range between\n '(0, 0)' <> '(1, 1)'")
 
 func test_override_failure_message() -> void:
 	assert_vector2(Vector2.ONE, GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
-		.has_error_message("Custom failure message")
+		.has_failure_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitVector2AssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitVector2AssertImplTest.gd
@@ -5,6 +5,20 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit3/src/asserts/GdUnitVector2AssertImpl.gd'
 
+func test_is_null():
+	assert_vector2(null).is_null()
+	# should fail because the current is not null
+	assert_vector2(Vector2.ONE, GdUnitAssert.EXPECT_FAIL) \
+		.is_null()\
+		.starts_with_error_message("Expecting: 'Null' but was '(1, 1)'")
+
+func test_is_not_null():
+	assert_vector2(Vector2.ONE).is_not_null()
+	# should fail because the current is null
+	assert_vector2(null, GdUnitAssert.EXPECT_FAIL) \
+		.is_not_null()\
+		.has_error_message("Expecting: not to be 'Null'")
+
 func test_is_equal() -> void:
 	assert_vector2(Vector2.ONE).is_equal(Vector2.ONE)
 	assert_vector2(Vector2.INF).is_equal(Vector2.INF)
@@ -107,3 +121,9 @@ func test_is_not_between_fail():
 	assert_vector2(Vector2.ONE, GdUnitAssert.EXPECT_FAIL)\
 		.is_not_between(Vector2.ZERO, Vector2.ONE)\
 		.has_error_message("Expecting:\n '(1, 1)'\n not in range between\n '(0, 0)' <> '(1, 1)'")
+
+func test_override_failure_message() -> void:
+	assert_vector2(Vector2.ONE, GdUnitAssert.EXPECT_FAIL)\
+		.override_failure_message("Custom failure message")\
+		.is_null()\
+		.has_error_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitVector3AssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitVector3AssertImplTest.gd
@@ -5,6 +5,20 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://addons/gdUnit3/src/asserts/GdUnitVector3AssertImpl.gd'
 
+func test_is_null():
+	assert_vector3(null).is_null()
+	# should fail because the current is not null
+	assert_vector3(Vector3.ONE, GdUnitAssert.EXPECT_FAIL) \
+		.is_null()\
+		.starts_with_error_message("Expecting: 'Null' but was '(1, 1, 1)'")
+
+func test_is_not_null():
+	assert_vector3(Vector3.ONE).is_not_null()
+	# should fail because the current is null
+	assert_vector3(null, GdUnitAssert.EXPECT_FAIL) \
+		.is_not_null()\
+		.has_error_message("Expecting: not to be 'Null'")
+
 func test_is_equal() -> void:
 	assert_vector3(Vector3.ONE).is_equal(Vector3.ONE)
 	assert_vector3(Vector3.INF).is_equal(Vector3.INF)
@@ -107,3 +121,9 @@ func test_is_not_between_fail():
 	assert_vector3(Vector3.ONE, GdUnitAssert.EXPECT_FAIL)\
 		.is_not_between(Vector3.ZERO, Vector3.ONE)\
 		.has_error_message("Expecting:\n '(1, 1, 1)'\n not in range between\n '(0, 0, 0)' <> '(1, 1, 1)'")
+
+func test_override_failure_message() -> void:
+	assert_vector2(Vector3.ONE, GdUnitAssert.EXPECT_FAIL)\
+		.override_failure_message("Custom failure message")\
+		.is_null()\
+		.has_error_message("Custom failure message")

--- a/addons/gdUnit3/test/asserts/GdUnitVector3AssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitVector3AssertImplTest.gd
@@ -10,14 +10,14 @@ func test_is_null():
 	# should fail because the current is not null
 	assert_vector3(Vector3.ONE, GdUnitAssert.EXPECT_FAIL) \
 		.is_null()\
-		.starts_with_error_message("Expecting: 'Null' but was '(1, 1, 1)'")
+		.starts_with_failure_message("Expecting: 'Null' but was '(1, 1, 1)'")
 
 func test_is_not_null():
 	assert_vector3(Vector3.ONE).is_not_null()
 	# should fail because the current is null
 	assert_vector3(null, GdUnitAssert.EXPECT_FAIL) \
 		.is_not_null()\
-		.has_error_message("Expecting: not to be 'Null'")
+		.has_failure_message("Expecting: not to be 'Null'")
 
 func test_is_equal() -> void:
 	assert_vector3(Vector3.ONE).is_equal(Vector3.ONE)
@@ -27,7 +27,7 @@ func test_is_equal() -> void:
 	# false test
 	assert_vector3(Vector3.ONE, GdUnitAssert.EXPECT_FAIL)\
 		.is_equal(Vector3(1.2, 1.000001, 1))\
-		.has_error_message("Expecting:\n '(1.2, 1.000001, 1)'\n but was\n '(1, 1, 1)'")
+		.has_failure_message("Expecting:\n '(1.2, 1.000001, 1)'\n but was\n '(1, 1, 1)'")
 
 func test_is_not_equal() -> void:
 	assert_vector3(Vector3.ONE).is_not_equal(Vector3.INF)
@@ -37,7 +37,7 @@ func test_is_not_equal() -> void:
 	# false test
 	assert_vector3(Vector3(1.2, 1.000001, 1), GdUnitAssert.EXPECT_FAIL)\
 		.is_not_equal(Vector3(1.2, 1.000001, 1))\
-		.has_error_message("Expecting:\n '(1.2, 1.000001, 1)'\n not equal to\n '(1.2, 1.000001, 1)'")
+		.has_failure_message("Expecting:\n '(1.2, 1.000001, 1)'\n not equal to\n '(1.2, 1.000001, 1)'")
 
 func test_is_equal_approx() -> void:
 	assert_vector3(Vector3.ONE).is_equal_approx(Vector3.ONE, Vector3(0.004, 0.004, 0.004))
@@ -47,10 +47,10 @@ func test_is_equal_approx() -> void:
 	# false test
 	assert_vector3(Vector3(1.005, 1, 1), GdUnitAssert.EXPECT_FAIL)\
 		.is_equal_approx(Vector3.ONE, Vector3(0.004, 0.004, 0.004))\
-		.has_error_message("Expecting:\n '(1.005, 1, 1)'\n in range between\n '(0.996, 0.996, 0.996)' <> '(1.004, 1.004, 1.004)'")
+		.has_failure_message("Expecting:\n '(1.005, 1, 1)'\n in range between\n '(0.996, 0.996, 0.996)' <> '(1.004, 1.004, 1.004)'")
 	assert_vector3(Vector3(1, 0.995, 1), GdUnitAssert.EXPECT_FAIL)\
 		.is_equal_approx(Vector3.ONE, Vector3(0, 0.004, 0))\
-		.has_error_message("Expecting:\n '(1, 0.995, 1)'\n in range between\n '(1, 0.996, 1)' <> '(1, 1.004, 1)'")
+		.has_failure_message("Expecting:\n '(1, 0.995, 1)'\n in range between\n '(1, 0.996, 1)' <> '(1, 1.004, 1)'")
 
 func test_is_less() -> void:
 	assert_vector3(Vector3.ONE).is_less(Vector3.INF)
@@ -59,10 +59,10 @@ func test_is_less() -> void:
 	# false test
 	assert_vector3(Vector3.ONE, GdUnitAssert.EXPECT_FAIL)\
 		.is_less(Vector3.ONE)\
-		.has_error_message("Expecting to be less than:\n '(1, 1, 1)' but was '(1, 1, 1)'")
+		.has_failure_message("Expecting to be less than:\n '(1, 1, 1)' but was '(1, 1, 1)'")
 	assert_vector3(Vector3(1.2, 1.000001, 1), GdUnitAssert.EXPECT_FAIL)\
 		.is_less(Vector3(1.2, 1.000001, 1))\
-		.has_error_message("Expecting to be less than:\n '(1.2, 1.000001, 1)' but was '(1.2, 1.000001, 1)'")
+		.has_failure_message("Expecting to be less than:\n '(1.2, 1.000001, 1)' but was '(1.2, 1.000001, 1)'")
 
 func test_is_less_equal() -> void:
 	assert_vector3(Vector3.ONE).is_less_equal(Vector3.INF)
@@ -72,10 +72,10 @@ func test_is_less_equal() -> void:
 	# false test
 	assert_vector3(Vector3.ONE, GdUnitAssert.EXPECT_FAIL)\
 		.is_less_equal(Vector3.ZERO)\
-		.has_error_message("Expecting to be less than or equal:\n '(0, 0, 0)' but was '(1, 1, 1)'")
+		.has_failure_message("Expecting to be less than or equal:\n '(0, 0, 0)' but was '(1, 1, 1)'")
 	assert_vector3(Vector3(1.2, 1.00002, 1), GdUnitAssert.EXPECT_FAIL)\
 		.is_less_equal(Vector3(1.2, 1.00001, 1))\
-		.has_error_message("Expecting to be less than or equal:\n '(1.2, 1.00001, 1)' but was '(1.2, 1.00002, 1)'")
+		.has_failure_message("Expecting to be less than or equal:\n '(1.2, 1.00001, 1)' but was '(1.2, 1.00002, 1)'")
 
 
 func test_is_greater() -> void:
@@ -85,10 +85,10 @@ func test_is_greater() -> void:
 	# false test
 	assert_vector3(Vector3.ZERO, GdUnitAssert.EXPECT_FAIL)\
 		.is_greater(Vector3.ONE)\
-		.has_error_message("Expecting to be greater than:\n '(1, 1, 1)' but was '(0, 0, 0)'")
+		.has_failure_message("Expecting to be greater than:\n '(1, 1, 1)' but was '(0, 0, 0)'")
 	assert_vector3(Vector3(1.2, 1.000001, 1), GdUnitAssert.EXPECT_FAIL)\
 		.is_greater(Vector3(1.2, 1.000001, 1))\
-		.has_error_message("Expecting to be greater than:\n '(1.2, 1.000001, 1)' but was '(1.2, 1.000001, 1)'")
+		.has_failure_message("Expecting to be greater than:\n '(1.2, 1.000001, 1)' but was '(1.2, 1.000001, 1)'")
 
 func test_is_greater_equal() -> void:
 	assert_vector3(Vector3.INF).is_greater_equal(Vector3.ONE)
@@ -99,10 +99,10 @@ func test_is_greater_equal() -> void:
 	# false test
 	assert_vector3(Vector3.ZERO, GdUnitAssert.EXPECT_FAIL)\
 		.is_greater_equal(Vector3.ONE)\
-		.has_error_message("Expecting to be greater than or equal:\n '(1, 1, 1)' but was '(0, 0, 0)'")
+		.has_failure_message("Expecting to be greater than or equal:\n '(1, 1, 1)' but was '(0, 0, 0)'")
 	assert_vector3(Vector3(1.2, 1.00002, 1), GdUnitAssert.EXPECT_FAIL)\
 		.is_greater_equal(Vector3(1.2, 1.00003, 1))\
-		.has_error_message("Expecting to be greater than or equal:\n '(1.2, 1.00003, 1)' but was '(1.2, 1.00002, 1)'")
+		.has_failure_message("Expecting to be greater than or equal:\n '(1.2, 1.00003, 1)' but was '(1.2, 1.00002, 1)'")
 
 func test_is_between(fuzzer = Fuzzers.rangev3(Vector3.ZERO, Vector3.ONE)):
 	var value :Vector3 = fuzzer.next_value()
@@ -111,7 +111,7 @@ func test_is_between(fuzzer = Fuzzers.rangev3(Vector3.ZERO, Vector3.ONE)):
 func test_is_between_fail():
 	assert_vector3(Vector3(1, 1.00001, 1), GdUnitAssert.EXPECT_FAIL)\
 		.is_between(Vector3.ZERO, Vector3.ONE)\
-		.has_error_message("Expecting:\n '(1, 1.00001, 1)'\n in range between\n '(0, 0, 0)' <> '(1, 1, 1)'")
+		.has_failure_message("Expecting:\n '(1, 1.00001, 1)'\n in range between\n '(0, 0, 0)' <> '(1, 1, 1)'")
 
 func test_is_not_between(fuzzer = Fuzzers.rangev3(Vector3.ZERO, Vector3.ONE)):
 	var value :Vector3 = fuzzer.next_value()
@@ -120,10 +120,10 @@ func test_is_not_between(fuzzer = Fuzzers.rangev3(Vector3.ZERO, Vector3.ONE)):
 func test_is_not_between_fail():
 	assert_vector3(Vector3.ONE, GdUnitAssert.EXPECT_FAIL)\
 		.is_not_between(Vector3.ZERO, Vector3.ONE)\
-		.has_error_message("Expecting:\n '(1, 1, 1)'\n not in range between\n '(0, 0, 0)' <> '(1, 1, 1)'")
+		.has_failure_message("Expecting:\n '(1, 1, 1)'\n not in range between\n '(0, 0, 0)' <> '(1, 1, 1)'")
 
 func test_override_failure_message() -> void:
 	assert_vector2(Vector3.ONE, GdUnitAssert.EXPECT_FAIL)\
 		.override_failure_message("Custom failure message")\
 		.is_null()\
-		.has_error_message("Custom failure message")
+		.has_failure_message("Custom failure message")

--- a/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailAndOrpahnsDetected.resource
+++ b/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailAndOrpahnsDetected.resource
@@ -27,7 +27,7 @@ func test_case2():
 	_orphans.append(Node.new())
 	_orphans.append(Node.new())
 	_orphans.append(Node.new())
-	assert_str("test_case2").as_error_message("faild on test_case2()").is_empty()
+	assert_str("test_case2").override_failure_message("faild on test_case2()").is_empty()
 
 # we manually freeing the orphans from the simulated testsuite to prevent memory leaks here
 func _notification(what):

--- a/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailOnMultipeStages.resource
+++ b/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailOnMultipeStages.resource
@@ -5,17 +5,17 @@ func before():
 	assert_str("suite before").is_equal("suite before")
 
 func after():
-	assert_str("suite after").as_error_message("failed on after()").is_empty()
+	assert_str("suite after").override_failure_message("failed on after()").is_empty()
 
 func before_test():
-	assert_str("test before").as_error_message("failed on before_test()").is_empty()
+	assert_str("test before").override_failure_message("failed on before_test()").is_empty()
 
 func after_test():
 	assert_str("test after").is_equal("test after")
 
 func test_case1():
-	assert_str("test_case1").as_error_message("failed 1 on test_case1()").is_empty()
-	assert_str("test_case1").as_error_message("failed 2 on test_case1()").is_empty()
+	assert_str("test_case1").override_failure_message("failed 1 on test_case1()").is_empty()
+	assert_str("test_case1").override_failure_message("failed 2 on test_case1()").is_empty()
 
 func test_case2():
 	assert_str("test_case2").is_equal("test_case2")

--- a/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailOnStageAfter.resource
+++ b/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailOnStageAfter.resource
@@ -5,7 +5,7 @@ func before():
 	assert_str("suite before").is_equal("suite before")
 
 func after():
-	assert_str("suite after").as_error_message("failed on after()").is_empty()
+	assert_str("suite after").override_failure_message("failed on after()").is_empty()
 
 func before_test():
 	assert_str("test before").is_equal("test before")

--- a/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailOnStageAfterTest.resource
+++ b/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailOnStageAfterTest.resource
@@ -11,7 +11,7 @@ func before_test():
 	assert_str("test before").is_equal("test before")
 
 func after_test():
-	assert_str("test after").as_error_message("failed on after_test()").is_empty()
+	assert_str("test after").override_failure_message("failed on after_test()").is_empty()
 
 func test_case1():
 	assert_str("test_case1").is_equal("test_case1")

--- a/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailOnStageBefore.resource
+++ b/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailOnStageBefore.resource
@@ -2,7 +2,7 @@
 extends GdUnitTestSuite
 
 func before():
-	assert_str("suite before").as_error_message("failed on before()").is_empty()
+	assert_str("suite before").override_failure_message("failed on before()").is_empty()
 
 func after():
 	assert_str("suite after").is_equal("suite after")

--- a/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailOnStageBeforeTest.resource
+++ b/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailOnStageBeforeTest.resource
@@ -8,7 +8,7 @@ func after():
 	assert_str("suite after").is_equal("suite after")
 
 func before_test():
-	assert_str("test before").as_error_message("failed on before_test()").is_empty()
+	assert_str("test before").override_failure_message("failed on before_test()").is_empty()
 
 func after_test():
 	assert_str("test after").is_equal("test after")

--- a/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailOnStageTestCase1.resource
+++ b/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailOnStageTestCase1.resource
@@ -14,7 +14,7 @@ func after_test():
 	assert_str("test after").is_equal("test after")
 
 func test_case1():
-	assert_str("test_case1").as_error_message("failed on test_case1()").is_empty()
+	assert_str("test_case1").override_failure_message("failed on test_case1()").is_empty()
 
 func test_case2():
 	assert_str("test_case2").is_equal("test_case2")

--- a/addons/gdUnit3/test/fuzzers/GdUnitFuzzerValueInjectionTest.gd
+++ b/addons/gdUnit3/test/fuzzers/GdUnitFuzzerValueInjectionTest.gd
@@ -84,7 +84,7 @@ func test_fuzzer_error_after_eight_iterations(fuzzer=TestFuzzer.new(), fuzzer_it
 	if fuzzer.iteration_index() == 8:
 		assert_int(fuzzer.next_value(), GdUnitAssert.EXPECT_FAIL) \
 			.is_between(0, 9) \
-			.has_error_message("Expecting:\n '23'\n in range between\n '0' <> '9'")
+			.has_failure_message("Expecting:\n '23'\n in range between\n '0' <> '9'")
 	else:
 		assert_int(fuzzer.next_value()).is_between(0, 9)
 

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -26,7 +26,7 @@ func test_is_mockable_godot_classes():
 		# protected classes (name starts with underscore)
 		var is_mockable :bool = not Engine.has_singleton(clazz_name) and ClassDB.can_instance(clazz_name) and clazz_name.find("_") != 0
 		assert_that(GdUnitMockBuilder.is_mockable(clazz_name)) \
-			.as_error_message("Class '%s' expect mockable %s" % [clazz_name, is_mockable]) \
+			.override_failure_message("Class '%s' expect mockable %s" % [clazz_name, is_mockable]) \
 			.is_equal(is_mockable)
 
 func test_is_mockable_by_class_type():
@@ -46,11 +46,11 @@ func test_is_mockable_by_script_path():
 func test_is_mockable__overriden_func_get_class():
 	# test with class type
 	assert_that(GdUnitMockBuilder.is_mockable(OverridenGetClassTestClass))\
-		.as_error_message("The class 'CustomResourceTestClass' should be mockable when 'func get_class()' is overriden")\
+		.override_failure_message("The class 'CustomResourceTestClass' should be mockable when 'func get_class()' is overriden")\
 		.is_true()
 	# test with resource path
 	assert_that(GdUnitMockBuilder.is_mockable(resource_path + "OverridenGetClassTestClass.gd"))\
-		.as_error_message("The class 'CustomResourceTestClass' should be mockable when 'func get_class()' is overriden")\
+		.override_failure_message("The class 'CustomResourceTestClass' should be mockable when 'func get_class()' is overriden")\
 		.is_true()
 
 
@@ -60,7 +60,7 @@ func test_mock_godot_class_fullcheck(fuzzer=GodotClassNameFuzzer.new(), fuzzer_i
 	if GdUnitMockBuilder.is_mockable(clazz_name):
 		var mock = mock(clazz_name, CALL_REAL_FUNC)
 		assert_that(mock)\
-			.as_error_message("The class %s should be mockable" % clazz_name)\
+			.override_failure_message("The class %s should be mockable" % clazz_name)\
 			.is_not_null()
 
 func test_mock_by_script_path():

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -15,7 +15,7 @@ func assert_last_error(expected :String):
 	var gd_assert := GdUnitAssertImpl.new(self, "")
 	if Engine.has_meta(GdAssertReports.LAST_ERROR):
 		gd_assert._current_error_message = Engine.get_meta(GdAssertReports.LAST_ERROR)
-	gd_assert.has_error_message(expected)
+	gd_assert.has_failure_message(expected)
 
 func test_is_mockable_godot_classes():
 	# verify enigne classes
@@ -706,7 +706,7 @@ But found interactions on:
 	expected_error = GdScriptParser.to_unix_format(expected_error)
 	# it should fail because we have interactions 
 	verify_no_interactions(mocked_node, GdUnitAssert.EXPECT_FAIL)\
-		.has_error_message(expected_error)
+		.has_failure_message(expected_error)
 
 func test_verify_no_more_interactions():
 	var mocked_node :Node = mock(Node)
@@ -754,7 +754,7 @@ But found interactions on:
 	'find_node(mask :String, False :bool, False :bool)'	1 time's"""
 	expected_error = GdScriptParser.to_unix_format(expected_error)
 	verify_no_more_interactions(mocked_node, GdUnitAssert.EXPECT_FAIL)\
-		.has_error_message(expected_error)
+		.has_failure_message(expected_error)
 
 func test_mock_snake_case_named_class_by_resource_path():
 	var mock_a = mock("res://addons/gdUnit3/test/mocker/resources/snake_case.gd")

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -6,7 +6,7 @@ func assert_last_error(expected :String):
 	var gd_assert := GdUnitAssertImpl.new(self, "")
 	if Engine.has_meta(GdAssertReports.LAST_ERROR):
 		gd_assert._current_error_message = Engine.get_meta(GdAssertReports.LAST_ERROR)
-	gd_assert.has_error_message(expected)
+	gd_assert.has_failure_message(expected)
 
 func test_cant_spy_is_not_a_instance():
 	# returns null because spy needs an 'real' instance to by spy on
@@ -208,7 +208,7 @@ But found interactions on:
 	expected_error = GdScriptParser.to_unix_format(expected_error)
 	# it should fail because we have interactions 
 	verify_no_interactions(spy_node, GdUnitAssert.EXPECT_FAIL)\
-		.has_error_message(expected_error)
+		.has_failure_message(expected_error)
 
 func test_verify_no_more_interactions():
 	var instance :Node = auto_free(Node.new())
@@ -258,7 +258,7 @@ But found interactions on:
 	'find_node(mask :String, False :bool, False :bool)'	1 time's"""
 	expected_error = GdScriptParser.to_unix_format(expected_error)
 	verify_no_more_interactions(spy_node, GdUnitAssert.EXPECT_FAIL)\
-		.has_error_message(expected_error)
+		.has_failure_message(expected_error)
 
 class ClassWithStaticFunctions:
 	


### PR DESCRIPTION
- GdUnitAssert is the base class of all GdUnit asserts and provides the most common test functions
  -- added missing 'is_null()' and 'is_not_null()'
- renamed 'as_error_message(message' to 'override_failure_message' to get more clear what this function does
- added test coverage for 'is_null()' and 'is_not_null()' to all assert integration tests