### PR TITLE
GD-102: Fix orphan nodes detected during export via command line.

### DIFF
--- a/addons/gdUnit3/plugin.gd
+++ b/addons/gdUnit3/plugin.gd
@@ -22,7 +22,7 @@ func _enter_tree():
 	# needs to wait before we can add a child to the root
 	yield(get_tree(), "idle_frame")
 	_server_node = load("res://addons/gdUnit3/src/network/GdUnitServer.tscn").instance()
-	get_tree().root.add_child(_server_node)
+	add_child(_server_node)
 	var err := _gd_inspector.connect("gdunit_runner_stop", _server_node, "_on_gdunit_runner_stop")
 	if err != OK:
 		prints("ERROR", GdUnitTools.error_as_string(err))
@@ -31,13 +31,16 @@ func _enter_tree():
 func _exit_tree():
 	remove_control_from_docks(_gd_inspector)
 	remove_control_from_bottom_panel(_gd_console)
-	get_tree().root.remove_child(_server_node)
+	remove_child(_server_node)
 	
-	_server_node.queue_free()
-	_gd_inspector.queue_free()
-	_gd_console.queue_free()
+	_gd_inspector.free()
+	_gd_console.free()
+	_server_node.free()
 	GdUnitSingleton.remove_singleton(SignalHandler.SINGLETON_NAME)
+	Engine.remove_meta("GdUnitEditorPlugin")
 	prints("Unload GdUnit3 Plugin success")
+
+
 
 #func make_visible(visible: bool):
 #	if _gd_inspector:

--- a/addons/gdUnit3/src/core/GdUnitSingleton.gd
+++ b/addons/gdUnit3/src/core/GdUnitSingleton.gd
@@ -7,7 +7,7 @@
 class_name GdUnitSingleton
 extends Resource
 
-const _singletons:Dictionary = Dictionary()
+const _singletons :Dictionary = Dictionary()
 
 static func get_singleton(name: String) -> Object:
 	if _singletons.has(name):
@@ -33,5 +33,3 @@ static func remove_singleton(name: String) -> void:
 		_singletons.erase(name)
 		return
 	push_error("Remove singleton '" + name + "' failed. No global instance found.")
-
-

--- a/addons/gdUnit3/src/network/GdUnitTcpClient.gd
+++ b/addons/gdUnit3/src/network/GdUnitTcpClient.gd
@@ -90,7 +90,7 @@ func is_client_connected() -> bool:
 
 func process_rpc() -> void:
 	if _stream.get_available_bytes() > 0:
-		var rpc := RPC.deserialize(_stream.get_var())
+		var rpc = RPC.deserialize(_stream.get_var())
 		if rpc is RPCClientDisconnect:
 			stop()
 

--- a/addons/gdUnit3/src/network/GdUnitTcpServer.gd
+++ b/addons/gdUnit3/src/network/GdUnitTcpServer.gd
@@ -41,7 +41,7 @@ class TcpConnection extends Node:
 			var data_received = _stream.get_var(true)
 			if data_received == null:
 				return
-			var rpc := RPC.deserialize(data_received)
+			var rpc = RPC.deserialize(data_received)
 			if rpc is RPCClientDisconnect:
 				close()
 			get_parent().emit_signal("rpc_data", rpc)
@@ -78,6 +78,7 @@ func stop() -> void:
 	for connection in get_children():
 		if connection is TcpConnection:
 			connection.close()
+			remove_child(connection)
 
 func disconnect_client(client_id :int) -> void:
 	for connection in get_children():

--- a/addons/gdUnit3/src/network/rpc/RPC.gd
+++ b/addons/gdUnit3/src/network/rpc/RPC.gd
@@ -4,9 +4,10 @@ extends Reference
 func serialize() -> Dictionary:
 	return inst2dict(self)
 
+# using untyped version see comments below
 static func deserialize(data :Dictionary):
 	return dict2inst(data)
 
-# this results in orpan node, create a Godot issue for this
+# this results in orpan node, for more details https://github.com/godotengine/godot/issues/50069
 #func deserialize2(data :Dictionary) -> RPC:
 #	return  dict2inst(data) as RPC

--- a/addons/gdUnit3/src/network/rpc/RPC.gd
+++ b/addons/gdUnit3/src/network/rpc/RPC.gd
@@ -4,5 +4,9 @@ extends Reference
 func serialize() -> Dictionary:
 	return inst2dict(self)
 
-static func deserialize(data :Dictionary) -> RPC:
-	return dict2inst(data) as RPC
+static func deserialize(data :Dictionary):
+	return dict2inst(data)
+
+# this results in orpan node, create a Godot issue for this
+#func deserialize2(data :Dictionary) -> RPC:
+#	return  dict2inst(data) as RPC

--- a/addons/gdUnit3/src/ui/parts/InspectorStatusBar.gd
+++ b/addons/gdUnit3/src/ui/parts/InspectorStatusBar.gd
@@ -18,8 +18,8 @@ func _ready():
 	_signal_handler.register_on_gdunit_events(self, "_on_event")
 	_failures.text = "0"
 	_errors.text = "0"
-	
-	var editor := EditorPlugin.new()
+
+	var editor :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
 	var editiorTheme := editor.get_editor_interface().get_base_control().theme
 	_button_failure_up.icon = editiorTheme.get_icon("ArrowUp", "EditorIcons")
 	_button_failure_down.icon = editiorTheme.get_icon("ArrowDown", "EditorIcons")

--- a/addons/gdUnit3/src/ui/parts/InspectorToolBar.gd
+++ b/addons/gdUnit3/src/ui/parts/InspectorToolBar.gd
@@ -12,11 +12,11 @@ onready var _button_run_debug := $Tools/debug
 onready var _button_stop := $Tools/stop
 
 func _ready():
-	var editor := EditorPlugin.new()
+	var editor :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
 	var editiorTheme := editor.get_editor_interface().get_base_control().theme
 	_button_run.icon = editiorTheme.get_icon("Play", "EditorIcons")
 	_button_stop.icon = editiorTheme.get_icon("Stop", "EditorIcons")
-	
+
 	var config = ConfigFile.new()
 	config.load('addons/gdUnit3/plugin.cfg')
 	var version = config.get_value('plugin', 'version')

--- a/addons/gdUnit3/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit3/src/ui/parts/InspectorTreeMainPanel.gd
@@ -92,13 +92,9 @@ static func is_item_state_orphan(item :TreeItem) -> bool:
 func _ready():
 	init_tree()
 	if Engine.editor_hint:
-		_editor = EditorPlugin.new()
+		_editor = Engine.get_meta("GdUnitEditorPlugin")
 	_signal_handler.register_on_test_suite_added(self, "_on_test_suite_added")
 	_signal_handler.register_on_gdunit_events(self, "_on_event")
-
-func _exit_tree():
-	if _editor:
-		_editor.free()
 
 static func load_resized_texture(path :String, width :int = 16, height :int = 16) -> Texture:
 	var texture :Texture = load(path)
@@ -151,7 +147,7 @@ func set_state_running(item :TreeItem) -> void:
 	item.collapsed = false
 	# force scrolling to current test case
 	select_item(item)
-	
+
 
 func set_state_succeded(item :TreeItem) -> void:
 	item.set_meta(META_GDUNIT_STATE, STATE.SUCCESS)


### PR DESCRIPTION
- removed usage of `EditorPlugin.new()` and using already stored meta info
- fix very strange bug on RPC.deserialize, the use of type save function declaration results in a orpan node