### PR TITLE
GD-106: Fix using add_child on before() in test suites do not break the API

### DIFF
--- a/addons/gdUnit3/src/core/GdUnitExecutor.gd
+++ b/addons/gdUnit3/src/core/GdUnitExecutor.gd
@@ -253,6 +253,9 @@ func execute(test_suite :GdUnitTestSuite) -> GDScriptFunctionState:
 	if not test_suite.is_skipped():
 		for test_case_index in test_suite.get_child_count():
 			var test_case = test_suite.get_child(test_case_index)
+			# only iterate over test case, we need to filter because of possible adding other child types on before() or before_test()
+			if not test_case is _TestCase:
+				continue
 			# stop on first error if fail fast enabled
 			if _fail_fast and _total_test_failed > 0:
 				break

--- a/addons/gdUnit3/test/core/GdUnitExecutorTest.gd
+++ b/addons/gdUnit3/test/core/GdUnitExecutorTest.gd
@@ -514,3 +514,31 @@ func test_execute_failure_fuzzer_iteration() -> void:
 		# must fail after three iterations
 		["Found an error after '3' test iterations Expecting: 'False' but is 'True'"],
 		[])
+
+func test_execute_add_child_on_before_GD_106() -> void:
+	var test_suite := resource("res://addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailAddChildStageBefore.resource")
+	# verify all test cases loaded
+	assert_array(test_suite.get_children()).extract("get_name").contains_exactly(["test_case1", "test_case2"])
+	# simulate test suite execution
+	var events = yield(execute(test_suite), "completed" )
+	# verify basis infos
+	assert_event_list(events, "TestSuiteFailAddChildStageBefore")
+	# verify all counters are zero / no errors, failures, orphans
+	assert_event_counters(events).contains_exactly([
+		tuple(GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
+	])
+	assert_event_states(events).contains_exactly([
+		tuple("before", true, false, false, false),
+		tuple("test_case1", true, false, false, false),
+		tuple("test_case1", true, false, false, false),
+		tuple("test_case2", true, false, false, false),
+		tuple("test_case2", true, false, false, false),
+		tuple("after", true, false, false, false),
+	])
+	# all success no reports expected
+	assert_event_reports(events, [], [], [], [], [], [])

--- a/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailAddChildStageBefore.resource
+++ b/addons/gdUnit3/test/core/resources/testsuites/TestSuiteFailAddChildStageBefore.resource
@@ -1,0 +1,11 @@
+# this test suite fails if (https://github.com/MikeSchulze/gdUnit3/issues/106) not fixed on iterating over testcases 
+extends GdUnitTestSuite
+
+func before():
+	add_child(auto_free(Node.new()))
+
+func test_case1():
+	assert_str("test_case1").is_equal("test_case1")
+
+func test_case2():
+	assert_str("test_case2").is_equal("test_case2")


### PR DESCRIPTION

- adding custom nodes on the test suite `before()` was break the test case execution
  solved by adding a typeof check when iteration over the childs to only execute on test case