### PR TITLE
GD-117: Fixed GdUnitInspector event handling for test-suites with same name

### DIFF
--- a/addons/gdUnit3/src/network/GdSerde.gd
+++ b/addons/gdUnit3/src/network/GdSerde.gd
@@ -6,7 +6,7 @@ extends Resource
 static func serialize_test_suite(test_suite:GdUnitTestSuite) -> Dictionary:
 	var serialized := Dictionary()
 	serialized["name"] = test_suite.get_name()
-	serialized["recource_path"] = test_suite.get_script().resource_path
+	serialized["resource_path"] = test_suite.get_script().resource_path
 	var test_cases := Array()
 	serialized["test_cases"] = test_cases
 	for test_case in test_suite.get_children():
@@ -14,7 +14,7 @@ static func serialize_test_suite(test_suite:GdUnitTestSuite) -> Dictionary:
 	return serialized
 	
 static func deserialize_test_suite(serialized:Dictionary) -> GdUnitTestSuite:
-	var resource_path:String = serialized["recource_path"]
+	var resource_path :String = serialized["resource_path"]
 	var test_suite := load(resource_path).new() as GdUnitTestSuite
 	test_suite.set_name(serialized["name"])
 	var test_cases:Array = serialized["test_cases"]

--- a/addons/gdUnit3/test/GdUnitTestResourceLoader.gd
+++ b/addons/gdUnit3/test/GdUnitTestResourceLoader.gd
@@ -1,9 +1,6 @@
 class_name GdUnitTestResourceLoader
 extends Reference
 
-static func extract_suite_name(resource_path :String) -> String:
-	return resource_path.get_file().replace(".resource", "")
-
 static func load_test_suite(resource_path :String) -> GdUnitTestSuite:
 	var script := GDScript.new()
 	script.source_code = GdUnitTools.resource_as_string(resource_path)
@@ -11,7 +8,7 @@ static func load_test_suite(resource_path :String) -> GdUnitTestSuite:
 	script.reload()
 	var test_suite :GdUnitTestSuite = GdUnitTestSuite.new()
 	test_suite.set_script(script)
-	test_suite.set_name(extract_suite_name(resource_path))
+	test_suite.set_name(_TestSuiteScanner.parse_test_suite_name(resource_path.replace(".resource", ".gd")))
 	# complete test suite wiht parsed test cases
 	var suite_parser := _TestSuiteScanner.new()
 	var test_case_names := suite_parser._extract_test_case_names(test_suite)

--- a/addons/gdUnit3/test/ui/parts/resources/bar/ExampleTestSuiteA.resource
+++ b/addons/gdUnit3/test/ui/parts/resources/bar/ExampleTestSuiteA.resource
@@ -1,0 +1,17 @@
+extends GdUnitTestSuite
+
+
+func test_aa() -> void:
+	pass
+
+func test_ab() -> void:
+	pass
+
+func test_ac() -> void:
+	pass
+
+func test_ad() -> void:
+	pass
+
+func test_ae() -> void:
+	pass

--- a/addons/gdUnit3/test/ui/parts/resources/foo/ExampleTestSuiteA.resource
+++ b/addons/gdUnit3/test/ui/parts/resources/foo/ExampleTestSuiteA.resource
@@ -1,0 +1,18 @@
+class_name ExampleTestSuiteA
+extends GdUnitTestSuite
+
+
+func test_aa() -> void:
+	pass
+
+func test_ab() -> void:
+	pass
+
+func test_ac() -> void:
+	pass
+
+func test_ad() -> void:
+	pass
+
+func test_ae() -> void:
+	pass

--- a/addons/gdUnit3/test/ui/parts/resources/foo/ExampleTestSuiteB.resource
+++ b/addons/gdUnit3/test/ui/parts/resources/foo/ExampleTestSuiteB.resource
@@ -1,0 +1,12 @@
+class_name ExampleTestSuiteB
+extends GdUnitTestSuite
+
+
+func test_ba() -> void:
+	pass
+
+func test_bb() -> void:
+	pass
+
+func test_bc() -> void:
+	pass

--- a/addons/gdUnit3/test/ui/parts/resources/foo/ExampleTestSuiteC.resource
+++ b/addons/gdUnit3/test/ui/parts/resources/foo/ExampleTestSuiteC.resource
@@ -1,0 +1,18 @@
+class_name ExampleTestSuiteC
+extends GdUnitTestSuite
+
+
+func test_ca() -> void:
+	pass
+
+func test_cb() -> void:
+	pass
+
+func test_cc() -> void:
+	pass
+
+func test_cd() -> void:
+	pass
+
+func test_ce() -> void:
+	pass

--- a/project.godot
+++ b/project.godot
@@ -584,7 +584,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gdUnit3/test/update/GdUnitPatcherTest.gd"
 }, {
-"base": "Node",
+"base": "Reference",
 "class": "GdUnitPushErrorHandler",
 "language": "GDScript",
 "path": "res://addons/gdUnit3/src/network/GdUnitPushErrorHandler.gd"
@@ -1211,10 +1211,6 @@ limits/debugger_stdout/max_chars_per_second=60048
 limits/debugger_stdout/max_messages_per_frame=100
 limits/debugger_stdout/max_errors_per_second=1000
 limits/debugger_stdout/max_warnings_per_second=1000
-
-[physics]
-
-3d/physics_engine="GodotPhysics"
 
 [rendering]
 


### PR DESCRIPTION

- The GdUnitInspector was not able to correctly address events for test suites with the same name.
- Fixed it by using the resource_path instead of suite name to adress the correct item in the inspector