### PR TITLE
GD-120: Added time factor functionallity to scene runner to speedup scene testing

### DIFF
--- a/gdUnit3-examples/RoomDemo3D/test/rooms/RoomWithDoorTest.gd
+++ b/gdUnit3-examples/RoomDemo3D/test/rooms/RoomWithDoorTest.gd
@@ -5,7 +5,6 @@ extends GdUnitTestSuite
 # TestSuite generated from
 const __source = 'res://gdUnit3-examples/RoomDemo3D/src/rooms/RoomWithDoor.gd'
 
-
 var _runner :GdUnitSceneRunner
 var _scene: Node
 var _door: Door
@@ -15,6 +14,8 @@ func before_test() -> void:
 	# we use before_test to have this code only once and reuse for each test
 	_scene = spy("res://gdUnit3-examples/RoomDemo3D/src/rooms/RoomWithDoor.tscn")
 	_runner = scene_runner(_scene)
+	# set time factor to 10 to simulate the scene very fast
+	_runner.set_time_factor(10)
 	# enable this line to show the running scene during test execution
 	_runner.maximize_view()
 	# door not cloesed yet
@@ -24,16 +25,32 @@ func before_test() -> void:
 	# door is initial started to closing
 	assert_int(_door.state()).is_equal(Door.STATE.START_CLOSE)
 
+# this example using simulate frames with a delta time peer frame
+# ! the time factor is ignoring when using `simulate(frames: int, delta_peer_frame :float)`
 # this test shows the inital scene, the door is open and auto closed on startup
-func test_simulate_scene_by_frames() -> void:
+func test_simulate_scene_by_frames_and_delta() -> void:
 	# run the scene for 10 frames each frame with a delta of 10ms
 	yield(_runner.simulate(10, .010), "completed")
 	# the door is not closed yet, it is sill in closing animation
 	assert_int(_door.state()).is_equal(Door.STATE.START_CLOSE)
 	verify(_scene, 0)._on_door_door_closed(any())
 	
-	# run next 20 frames, the door should be closed after 30 frames
-	yield(_runner.simulate(20, .010), "completed")
+	# run next 50 frames, the door should be closed after 50 frames
+	yield(_runner.simulate(50, .010), "completed")
+	# verify the door is closed by the `_on_door_door_closed` is called
+	assert_int(_door.state()).is_equal(Door.STATE.CLOSE)
+	verify(_scene, 1)._on_door_door_closed(any())
+
+# this test shows the inital scene, the door is open and auto closed on startup
+func test_simulate_scene_by_frames_with_time_shift() -> void:
+	# run the scene for 10 frames
+	yield(_runner.simulate_frames(10), "completed")
+	# the door is not closed yet, it is sill in closing animation
+	assert_int(_door.state()).is_equal(Door.STATE.START_CLOSE)
+	verify(_scene, 0)._on_door_door_closed(any())
+	
+	# run next 50 frames
+	yield(_runner.simulate_frames(50), "completed")
 	# verify the door is closed by the `_on_door_door_closed` is called
 	assert_int(_door.state()).is_equal(Door.STATE.CLOSE)
 	verify(_scene, 1)._on_door_door_closed(any())
@@ -56,18 +73,17 @@ func test_simulate_trigger_open_door(timeout = 5000) -> void:
 	# move the player short before open door trigger areaa
 	_player.transform.origin.z -= 3
 	# continue scene runnung and weit for 60 frames 
-	yield(_runner.simulate(60, .010), "completed")
+	yield(_runner.simulate_frames(60), "completed")
 	assert_int(_door.state()).is_equal(Door.STATE.CLOSE)
 	
 	# one step more and the door should be start to open
 	_player.transform.origin.z -= .7
 	# continue scene runnung for 10 frames the open animation shold be started
-	yield(_runner.simulate(10, .010), "completed")
+	yield(_runner.simulate_frames(10), "completed")
 	assert_int(_door.state()).is_equal(Door.STATE.START_OPEN)
 	
 	# finally we wait for the door open is completes
 	yield(_runner.simulate_until_signal("door_opened"), "completed")
-
 
 # this test moves the play in the door trigger arera to trigger an door open
 func test_simulate_process_pyhysics() -> void:
@@ -75,7 +91,7 @@ func test_simulate_process_pyhysics() -> void:
 	# the sponge is falling down
 	assert_bool(sponge.is_sleeping()).is_false()
 	# run 500 frames, time enough to bring the sponge down to the floor
-	yield(_runner.simulate(500, .010), "completed")
+	yield(_runner.simulate_frames(500), "completed")
 	
 	# the sponge should now be stay on the floor
 	assert_bool(sponge.is_sleeping()).is_true()


### PR DESCRIPTION

- with `set_time_factor(<time_shift>)` we can now control the time factor
- refactor RoomWithDoorTest example to use the new time factore functionallity to speed up this test suite (13s to 3s)