### PR TITLE
GD-122: Added `contains_exactly_in_any_order` to `GdUnitArrayAssert`

### DIFF
--- a/addons/gdUnit3/src/GdUnitArrayAssert.gd
+++ b/addons/gdUnit3/src/GdUnitArrayAssert.gd
@@ -47,6 +47,10 @@ func contains(expected) -> GdUnitArrayAssert:
 func contains_exactly(expected) -> GdUnitArrayAssert:
 	return self
 
+# Verifies that the current Array contains exactly only the given values and nothing else, in any order.
+func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
+	return self
+
 # Extracts all values by given function name and optional arguments into a new ArrayAssert
 # If the elements not accessible by `func_name` the value is converted to `"n.a"`, expecting null values
 func extract(func_name: String, args := Array()) -> GdUnitArrayAssert:

--- a/addons/gdUnit3/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit3/src/asserts/GdAssertMessages.gd
@@ -200,12 +200,34 @@ static func error_has_length(current, expected: int, compare_operator) -> String
 
 # - ArrayAssert specific messgaes ---------------------------------------------------
 static func error_arr_contains(current :Array, expected :Array, not_expect :Array, not_found :Array) -> String:
-	var error := "%s\n %s\n do contains\n %s" % [_error("Expecting:"), _current(current), _expected(expected)]
+	var error := "%s\n %s\n do contains (in any order)\n %s" % [_error("Expecting contains elements:"), _current(current, ", "), _expected(expected, ", ")]
 	if not not_expect.empty():
-		error += "\nbut some elements where not expected:\n %s" % _expected(not_expect)
+		error += "\nbut some elements where not expected:\n %s" % _expected(not_expect, ", ")
 	if not not_found.empty():
 		var prefix = "but" if not_expect.empty() else "and"
-		error += "\n%s could not find elements:\n %s" % [prefix, _expected(not_found)]
+		error += "\n%s could not find elements:\n %s" % [prefix, _expected(not_found, ", ")]
+	return error
+
+static func error_arr_contains_exactly(current :Array, expected :Array, not_expect :Array, not_found :Array) -> String:
+	if not_expect.empty() and not_found.empty():
+		var diff := _find_first_diff(current, expected)
+		return "%s\n %s\n do contains (in same order)\n %s\n but has different order %s"  % [_error("Expecting contains exactly elements:"), _current(current, ", "), _expected(expected, ", "), diff]
+	
+	var error := "%s\n %s\n do contains (in same order)\n %s" % [_error("Expecting contains exactly elements:"), _current(current, ", "), _expected(expected, ", ")]
+	if not not_expect.empty():
+		error += "\nbut some elements where not expected:\n %s" % _expected(not_expect, ", ")
+	if not not_found.empty():
+		var prefix = "but" if not_expect.empty() else "and"
+		error += "\n%s could not find elements:\n %s" % [prefix, _expected(not_found, ", ")]
+	return error
+
+static func error_arr_contains_exactly_in_any_order(current :Array, expected :Array, not_expect :Array, not_found :Array) -> String:
+	var error := "%s\n %s\n do contains exactly (in any order)\n %s" % [_error("Expecting contains exactly elements:"), _current(current, ", "), _expected(expected, ", ")]
+	if not not_expect.empty():
+		error += "\nbut some elements where not expected:\n %s" % _expected(not_expect, ", ")
+	if not not_found.empty():
+		var prefix = "but" if not_expect.empty() else "and"
+		error += "\n%s could not find elements:\n %s" % [prefix, _expected(not_found, ", ")]
 	return error
 
 # - DictionaryAssert specific messages ----------------------------------------------
@@ -300,22 +322,6 @@ static func _find_first_diff( left :Array, right :Array) -> String:
 		if not GdObjects.equals(l, r):
 			return "at position %s\n %s vs %s" % [_current(index), _current(l), _expected(r)]
 	return ""
-
-static func error_arr_contains_exactly(current :Array, expected :Array, not_expect :Array, not_found :Array) -> String:
-	if not_expect.empty() and not_found.empty():
-		var diff := _find_first_diff(current, expected)
-		return "%s\n %s\n %s\n but has different order %s"  % [_error("Expecting to have same elements and in same order:"), _current(current), _expected(expected), diff]
-	
-	var error := "%s\n %s\n do contains (in same order)\n %s" % [_error("Expecting:"), _current(current), _expected(expected)]
-	if not not_expect.empty():
-		error += "\nbut some elements where not expected:\n %s" % _expected(not_expect)
-	if not not_found.empty():
-		var prefix = "but" if not_expect.empty() else "and"
-		error += "\n%s could not find elements:\n %s" % [prefix, _expected(not_found)]
-	return error
-
-
-
 
 static func error_has_size(current: int, expected: int) -> String:
 	return "%s\n %s\n but was\n %s" % [_error("Expecting size:"), _expected(expected), _current(current)]

--- a/addons/gdUnit3/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitArrayAssertImpl.gd
@@ -12,6 +12,8 @@ func __current() -> Array:
 	return Array(_base._current)
 
 func __expected(expected) -> Array:
+	if typeof(expected) == TYPE_ARRAY:
+		return expected
 	return Array(expected)
 
 func report_success() -> GdUnitArrayAssert:
@@ -141,7 +143,7 @@ func contains_exactly(expected) -> GdUnitArrayAssert:
 	if GdObjects.equals(current_, expected_):
 		return report_success()
 	# check has same elements but in different order
-
+	
 	if GdObjects.equals_sorted(current_, expected_):
 		return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected_, [], []))
 	# find the difference
@@ -149,6 +151,21 @@ func contains_exactly(expected) -> GdUnitArrayAssert:
 	var not_expect := diffs[0] as Array
 	var not_found := diffs[1] as Array
 	return report_error(GdAssertMessages.error_arr_contains_exactly(current_, expected_, not_expect, not_found))
+
+# Verifies that the current Array contains exactly only the given values and nothing else, in any order.
+func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
+	var current_ := __current()
+	var expected_ := __expected(expected)
+	
+	# find the difference
+	var diffs := array_div(current_, expected_, false)
+	var not_expect := diffs[0] as Array
+	var not_found := diffs[1] as Array
+	prints("not_expect", not_expect)
+	prints("not_found", not_found)
+	if not_expect.empty() and not_found.empty():
+		return report_success()
+	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected_, not_expect, not_found))
 
 func is_same(expected) -> GdUnitAssert:
 	_base.is_same(expected)

--- a/addons/gdUnit3/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitArrayAssertImpl.gd
@@ -161,8 +161,6 @@ func contains_exactly_in_any_order(expected) -> GdUnitArrayAssert:
 	var diffs := array_div(current_, expected_, false)
 	var not_expect := diffs[0] as Array
 	var not_found := diffs[1] as Array
-	prints("not_expect", not_expect)
-	prints("not_found", not_found)
 	if not_expect.empty() and not_found.empty():
 		return report_success()
 	return report_error(GdAssertMessages.error_arr_contains_exactly_in_any_order(current_, expected_, not_expect, not_found))

--- a/addons/gdUnit3/src/core/GdObjects.gd
+++ b/addons/gdUnit3/src/core/GdObjects.gd
@@ -168,7 +168,7 @@ static func equals(obj_a, obj_b, case_sensitive :bool = false, deep_check :bool 
 		return false
 	if obj_b == null and obj_a != null:
 		return false
-
+	
 	match type_a:
 		TYPE_OBJECT:
 			if deep_check:
@@ -201,7 +201,6 @@ static func equals(obj_a, obj_b, case_sensitive :bool = false, deep_check :bool 
 				return obj_a.to_lower() == obj_b.to_lower()
 			else:
 				return obj_a == obj_b
-
 	return obj_a == obj_b
 
 static func notification_as_string(notification :int) -> String:
@@ -503,6 +502,8 @@ static func array_to_string(elements, delimiter := "\n") -> String:
 		if formatted.length() > 0 :
 			formatted += delimiter
 		formatted += str(element)
+		if formatted.length() > 64:
+			return formatted + delimiter + "..."
 	return formatted
 
 # Filters an array by given value

--- a/addons/gdUnit3/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -66,22 +66,84 @@ func test_has_size():
 		.has_failure_message("Expecting size:\n '4'\n but was\n '5'")
 
 func test_contains():
+	assert_array([1, 2, 3, 4, 5]).contains([])
 	assert_array([1, 2, 3, 4, 5]).contains([5, 2])
+	assert_array([1, 2, 3, 4, 5]).contains([5, 4, 3, 2, 1])
 	# should fail because the array not contains 7 and 6
+	var expected_error_message := """Expecting contains elements:
+ 1, 2, 3, 4, 5
+ do contains (in any order)
+ 2, 7, 6
+but could not find elements:
+ 7, 6"""
 	assert_array([1, 2, 3, 4, 5], GdUnitAssert.EXPECT_FAIL) \
 		.contains([2, 7, 6])\
-		.has_failure_message("Expecting:\n 1\n2\n3\n4\n5\n do contains\n 2\n7\n6\nbut could not find elements:\n 7\n6")
+		.has_failure_message(expected_error_message)
 
 func test_contains_exactly():
 	assert_array([1, 2, 3, 4, 5]).contains_exactly([1, 2, 3, 4, 5])
 	# should fail because the array contains the same elements but in a different order
-	var expected_error_message := """Expecting to have same elements and in same order:
- 1\n2\n3\n4\n5
- 1\n4\n3\n2\n5
+	var expected_error_message := """Expecting contains exactly elements:
+ 1, 2, 3, 4, 5
+ do contains (in same order)
+ 1, 4, 3, 2, 5
  but has different order at position '1'
  '2' vs '4'"""
 	assert_array([1, 2, 3, 4, 5], GdUnitAssert.EXPECT_FAIL) \
 		.contains_exactly([1, 4, 3, 2, 5])\
+		.has_failure_message(expected_error_message)
+	
+	# should fail because the array contains more elements and in a different order
+	expected_error_message = """Expecting contains exactly elements:
+ 1, 2, 3, 4, 5, 6, 7
+ do contains (in same order)
+ 1, 4, 3, 2, 5
+but some elements where not expected:
+ 6, 7"""
+	assert_array([1, 2, 3, 4, 5, 6, 7], GdUnitAssert.EXPECT_FAIL) \
+		.contains_exactly([1, 4, 3, 2, 5])\
+		.has_failure_message(expected_error_message)
+	
+	# should fail because the array contains less elements and in a different order
+	expected_error_message = """Expecting contains exactly elements:
+ 1, 2, 3, 4, 5
+ do contains (in same order)
+ 1, 4, 3, 2, 5, 6, 7
+but could not find elements:
+ 6, 7"""
+	assert_array([1, 2, 3, 4, 5], GdUnitAssert.EXPECT_FAIL) \
+		.contains_exactly([1, 4, 3, 2, 5, 6, 7])\
+		.has_failure_message(expected_error_message)
+
+func test_contains_exactly_in_any_order():
+	assert_array([1, 2, 3, 4, 5]).contains_exactly_in_any_order([1, 2, 3, 4, 5])
+	assert_array([1, 2, 3, 4, 5]).contains_exactly_in_any_order([5, 3, 2, 4, 1])
+	assert_array([1, 2, 3, 4, 5]).contains_exactly_in_any_order([5, 1, 2, 4, 3])
+	
+	# should fail because the array contains not exactly the same elements in any order
+	var expected_error_message := """Expecting contains exactly elements:
+ 1, 2, 6, 4, 5
+ do contains exactly (in any order)
+ 5, 3, 2, 4, 1, 9, 10
+but some elements where not expected:
+ 6
+and could not find elements:
+ 3, 9, 10"""
+	assert_array([1, 2, 6, 4, 5], GdUnitAssert.EXPECT_FAIL) \
+		.contains_exactly_in_any_order([5, 3, 2, 4, 1, 9, 10])\
+		.has_failure_message(expected_error_message)
+		
+	#should fail because the array contains the same elements but in a different order
+	expected_error_message = """Expecting contains exactly elements:
+ 1, 2, 6, 9, 10, 4, 5
+ do contains exactly (in any order)
+ 5, 3, 2, 4, 1
+but some elements where not expected:
+ 6, 9, 10
+and could not find elements:
+ 3"""
+	assert_array([1, 2, 6, 9, 10, 4, 5], GdUnitAssert.EXPECT_FAIL) \
+		.contains_exactly_in_any_order([5, 3, 2, 4, 1])\
 		.has_failure_message(expected_error_message)
 
 func test_fluent():

--- a/addons/gdUnit3/test/asserts/GdUnitArrayAssertImpl_PoolByteArrayTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitArrayAssertImpl_PoolByteArrayTest.gd
@@ -68,16 +68,23 @@ func test_has_size():
 func test_contains():
 	assert_array(PoolByteArray([1, 2, 3, 4, 5])).contains(PoolByteArray([5, 2]))
 	# should fail because the array not contains 7 and 6
+	var expected_error := """Expecting contains elements:
+ 1, 2, 3, 4, 5
+ do contains (in any order)
+ 2, 7, 6
+but could not find elements:
+ 7, 6""" 
 	assert_array(PoolByteArray([1, 2, 3, 4, 5]), GdUnitAssert.EXPECT_FAIL) \
 		.contains(PoolByteArray([2, 7, 6]))\
-		.has_failure_message("Expecting:\n 1\n2\n3\n4\n5\n do contains\n 2\n7\n6\nbut could not find elements:\n 7\n6")
+		.has_failure_message(expected_error)
 
 func test_contains_exactly():
 	assert_array(PoolByteArray([1, 2, 3, 4, 5])).contains_exactly(PoolByteArray([1, 2, 3, 4, 5]))
 	# should fail because the array not contains same elements but in different order
-	var expected_error_message := """Expecting to have same elements and in same order:
- 1\n2\n3\n4\n5
- 1\n4\n3\n2\n5
+	var expected_error_message := """Expecting contains exactly elements:
+ 1, 2, 3, 4, 5
+ do contains (in same order)
+ 1, 4, 3, 2, 5
  but has different order at position '1'
  '2' vs '4'"""
 	assert_array(PoolByteArray([1, 2, 3, 4, 5]), GdUnitAssert.EXPECT_FAIL) \

--- a/addons/gdUnit3/test/update/GdUnitUpdateTest.gd
+++ b/addons/gdUnit3/test/update/GdUnitUpdateTest.gd
@@ -19,7 +19,7 @@ func test_extract_package() -> void:
 	var result := GdUnitUpdate._extract_package(source, dest)
 	assert_result(result).is_success()
 	assert_array(GdUnitTools.scan_dir(dest)).contains_exactly(["MikeSchulze-gdUnit3-910d61e"])
-	assert_array(GdUnitTools.scan_dir(dest + "/MikeSchulze-gdUnit3-910d61e")).contains_exactly([
+	assert_array(GdUnitTools.scan_dir(dest + "/MikeSchulze-gdUnit3-910d61e")).contains_exactly_in_any_order([
 		"addons",
 		"runtest.cmd",
 		"runtest.sh",


### PR DESCRIPTION
- added `contains_exactly_in_any_order` to alow compare arrays unordered
- improve the error messages
- fix random failing `GdUnitUpdateTest:test_extract_package` by using the new function