### PR TITLE
GD-124: Deletes now old artifacts before downlod the new update package

### DIFF
--- a/addons/gdUnit3/src/core/GdUnitTools.gd
+++ b/addons/gdUnit3/src/core/GdUnitTools.gd
@@ -108,7 +108,7 @@ static func current_dir() -> String:
 	return ProjectSettings.globalize_path("res://")
 
 
-static func delete_directory(path :String):
+static func delete_directory(path :String, only_content := false) -> void:
 	var dir := Directory.new()
 	if dir.open(path) == OK:
 		dir.list_dir_begin()
@@ -122,8 +122,13 @@ static func delete_directory(path :String):
 				delete_directory(next)
 			else:
 				# delete file
-				Directory.new().remove(next)
-		Directory.new().remove(path)
+				var err = Directory.new().remove(next)
+				if err:
+					push_error("Delete %s failed: %s" % [next, error_as_string(err)])
+		if not only_content:
+			var err := Directory.new().remove(path)
+			if err:
+				push_error("Delete %s failed: %s" % [path, error_as_string(err)])
 
 
 static func copy_file(from_file :String, to_dir :String) -> Result:

--- a/addons/gdUnit3/src/update/GdUnitUpdate.gd
+++ b/addons/gdUnit3/src/update/GdUnitUpdate.gd
@@ -116,12 +116,23 @@ static func close_open_editor_scripts() -> void:
 	script_editor._menu_option(MENU_ACTION_FILE_CLOSE_ALL)
 	plugin.free()
 
-func _on_update_pressed():
+func _prepare_update() -> Dictionary:
 	_update_in_progress = true
 	init_progress(9)
 	update_progress("Downloading update ..")
 	var tmp_path := GdUnitTools.create_temp_dir("update")
 	var zip_file := tmp_path + "/update.zip"
+	# cleanup old download data
+	GdUnitTools.delete_directory(tmp_path, true)
+	return {
+		"tmp_path" : tmp_path,
+		"zip_file" : zip_file
+	}
+
+func _on_update_pressed():
+	var paths := _prepare_update()
+	var zip_file = paths.get("zip_file")
+	var tmp_path = paths.get("tmp_path")
 	
 	var response :GdUnitUpdateClient.HttpResponse = yield(_update_client.request_zip_package(_download_zip_url, zip_file), "completed")
 	if response.code() != 200:

--- a/addons/gdUnit3/test/core/GdUnitToolsTest.gd
+++ b/addons/gdUnit3/test/core/GdUnitToolsTest.gd
@@ -164,3 +164,50 @@ func test_is_yielded() -> void:
 	# wait more than 2s and the function state should be invalid
 	yield(get_tree().create_timer(2.100),"timeout")
 	assert_bool(GdUnitTools.is_yielded(fs)).is_false()
+
+func _create_file(path :String, name :String) -> void:
+	var file := create_temp_file(path, name)
+	file.store_string("some content")
+	file.close()
+
+func test_delete_directory() -> void:
+	var tmp_dir := create_temp_dir("test_delete_dir")
+	create_temp_dir("test_delete_dir/data1")
+	create_temp_dir("test_delete_dir/data2")
+	_create_file("test_delete_dir", "example_a.txt")
+	_create_file("test_delete_dir", "example_b.txt")
+	_create_file("test_delete_dir/data1", "example.txt")
+	_create_file("test_delete_dir/data2", "example2.txt")
+	
+	assert_array(GdUnitTools.scan_dir(tmp_dir)).contains_exactly_in_any_order([
+		"data1",
+		"data2",
+		"example_a.txt",
+		"example_b.txt"
+	])
+	
+	# Delete the entire directory and its contents
+	GdUnitTools.delete_directory(tmp_dir)
+	assert_bool(Directory.new().dir_exists(tmp_dir)).is_false()
+	assert_array(GdUnitTools.scan_dir(tmp_dir)).is_empty()
+
+func test_delete_directory_content_only() -> void:
+	var tmp_dir := create_temp_dir("test_delete_dir")
+	create_temp_dir("test_delete_dir/data1")
+	create_temp_dir("test_delete_dir/data2")
+	_create_file("test_delete_dir", "example_a.txt")
+	_create_file("test_delete_dir", "example_b.txt")
+	_create_file("test_delete_dir/data1", "example.txt")
+	_create_file("test_delete_dir/data2", "example2.txt")
+	
+	assert_array(GdUnitTools.scan_dir(tmp_dir)).contains_exactly_in_any_order([
+		"data1",
+		"data2",
+		"example_a.txt",
+		"example_b.txt"
+	])
+	
+	# Delete the entire directory and its contents
+	GdUnitTools.delete_directory(tmp_dir, true)
+	assert_bool(Directory.new().dir_exists(tmp_dir)).is_true()
+	assert_array(GdUnitTools.scan_dir(tmp_dir)).is_empty()


### PR DESCRIPTION
- on multiple upgrade executions the download tmp directory was containing old extracted update data
  this was false used to install/update. Fixed by cleanup the tmp folder before unpack the update