### PR TITLE
GD-113: GdUnitUpdate now using the windows provided tar to unpack the update-zip

### DIFF
--- a/addons/gdUnit3/src/update/GdUnitUpdate.gd
+++ b/addons/gdUnit3/src/update/GdUnitUpdate.gd
@@ -203,10 +203,27 @@ static func disable_gdUnit() -> void:
 	plugin.get_editor_interface().set_plugin_enabled("gdUnit3", false)
 	plugin.free()
 
+
+static func _list_installed_tar_paths() -> PoolStringArray:
+	var stdout = Array()
+	OS.execute("where", ["tar"], true, stdout)
+	return PoolStringArray(stdout)
+
+static func _find_tar_path(os_name :String) -> String:
+	if os_name.to_upper() != "WINDOWS":
+		return "tar"
+	var paths := _list_installed_tar_paths()
+	for path in paths:
+		if path.find("\\System32\\tar") != -1:
+			return path.strip_escapes()
+	return "tar"
+
 static func _extract_package(source :String, dest:String) -> Result:
-	var err = OS.execute("tar", ["-xf", source, "-C", dest])
+	prints("Detect OS :", OS.get_name())
+	var tar_path := _find_tar_path( OS.get_name())
+	var err = OS.execute(tar_path, ["-xf", source, "-C", dest])
 	if err != 0:
-		var cmd = "tar -xf %s -C \"%s\"" % [source, dest]
+		var cmd = "%s -xf \"%s\" -C \"%s\"" % [tar_path, source, dest]
 		prints("Extracting by `%s` failed with error code: %d" % [cmd, err])
 		prints("Fallback to unzip")
 		err = OS.execute("unzip", [source, "-d", dest])

--- a/addons/gdUnit3/src/update/GdUnitUpdate.gd
+++ b/addons/gdUnit3/src/update/GdUnitUpdate.gd
@@ -203,7 +203,6 @@ static func disable_gdUnit() -> void:
 	plugin.get_editor_interface().set_plugin_enabled("gdUnit3", false)
 	plugin.free()
 
-
 static func _list_installed_tar_paths() -> PoolStringArray:
 	var stdout = Array()
 	OS.execute("where", ["tar"], true, stdout)

--- a/addons/gdUnit3/src/update/GdUnitUpdate.gd
+++ b/addons/gdUnit3/src/update/GdUnitUpdate.gd
@@ -207,7 +207,9 @@ static func disable_gdUnit() -> void:
 static func _list_installed_tar_paths() -> PoolStringArray:
 	var stdout = Array()
 	OS.execute("where", ["tar"], true, stdout)
-	return PoolStringArray(stdout)
+	if stdout.size() > 0:
+		return PoolStringArray(stdout[0].split("\n"))
+	return PoolStringArray()
 
 static func _find_tar_path(os_name :String) -> String:
 	if os_name.to_upper() != "WINDOWS":

--- a/addons/gdUnit3/test/update/GdUnitUpdateTest.gd
+++ b/addons/gdUnit3/test/update/GdUnitUpdateTest.gd
@@ -65,3 +65,31 @@ func test__prepare_update_deletes_old_content() -> void:
 	# call prepare update at twice where should cleanup old artifacts
 	update._prepare_update()
 	assert_array(GdUnitTools.scan_dir("user://tmp/update")).is_empty()
+
+func test_find_tar_path_on_windows() -> void:
+	# only execute this test on windows systems
+	if OS.get_name() == "Windows":
+		return
+	# simulate a OS window where many tar versions are installed
+	var update :GdUnitUpdate = mock(GdUnitUpdate, CALL_REAL_FUNC)
+	var possible_windows_paths = PoolStringArray([
+		"C:\\my_tar\\tar.exe",
+		"D:\\tools\\tar.exe",
+		"C:\\Windows\\System32\\tar.exe",
+	])
+	do_return(possible_windows_paths).on(update)._list_installed_tar_paths()
+	# on windows we want to find the windows provided tar version
+	assert_str(update._find_tar_path("Windows")).is_equal("C:\\Windows\\System32\\tar.exe")
+	
+	# Windows is installed on D:
+	possible_windows_paths = PoolStringArray([
+		"C:\\my_tar\\tar.exe",
+		"D:\\tools\\tar.exe",
+		"D:\\Windows\\System32\\tar.exe",
+	])
+	do_return(possible_windows_paths).on(update)._list_installed_tar_paths()
+	assert_str(update._find_tar_path("Windows")).is_equal("D:\\Windows\\System32\\tar.exe")
+
+func test_find_tar_path_on_non_windows() -> void:
+	assert_str(GdUnitUpdate._find_tar_path("MacOS")).is_equal("tar")
+	assert_str(GdUnitUpdate._find_tar_path("X11")).is_equal("tar")

--- a/addons/gdUnit3/test/update/GdUnitUpdateTest.gd
+++ b/addons/gdUnit3/test/update/GdUnitUpdateTest.gd
@@ -73,9 +73,7 @@ func test_find_tar_path_on_windows() -> void:
 	# simulate a OS window where many tar versions are installed
 	var update :GdUnitUpdate = mock(GdUnitUpdate, CALL_REAL_FUNC)
 	var possible_windows_paths = PoolStringArray([
-		"C:\\my_tar\\tar.exe",
-		"D:\\tools\\tar.exe",
-		"C:\\Windows\\System32\\tar.exe",
+		"C:\\my_tar\\tar.exe\nD:\\tools\\tar.exe\nD:\\Windows\\System32\\tar.exe",
 	])
 	do_return(possible_windows_paths).on(update)._list_installed_tar_paths()
 	# on windows we want to find the windows provided tar version
@@ -83,9 +81,7 @@ func test_find_tar_path_on_windows() -> void:
 	
 	# Windows is installed on D:
 	possible_windows_paths = PoolStringArray([
-		"C:\\my_tar\\tar.exe",
-		"D:\\tools\\tar.exe",
-		"D:\\Windows\\System32\\tar.exe",
+		"C:\\my_tar\\tar.exe\nD:\\tools\\tar.exe\nD:\\Windows\\System32\\tar.exe",
 	])
 	do_return(possible_windows_paths).on(update)._list_installed_tar_paths()
 	assert_str(update._find_tar_path("Windows")).is_equal("D:\\Windows\\System32\\tar.exe")

--- a/addons/gdUnit3/test/update/GdUnitUpdateTest.gd
+++ b/addons/gdUnit3/test/update/GdUnitUpdateTest.gd
@@ -68,12 +68,14 @@ func test__prepare_update_deletes_old_content() -> void:
 
 func test_find_tar_path_on_windows() -> void:
 	# only execute this test on windows systems
-	if OS.get_name() == "Windows":
+	if OS.get_name() != "Windows":
 		return
 	# simulate a OS window where many tar versions are installed
 	var update :GdUnitUpdate = mock(GdUnitUpdate, CALL_REAL_FUNC)
 	var possible_windows_paths = PoolStringArray([
-		"C:\\my_tar\\tar.exe\nD:\\tools\\tar.exe\nD:\\Windows\\System32\\tar.exe",
+		"C:\\my_tar\\tar.exe",
+		"D:\\tools\\tar.exe",
+		"C:\\Windows\\System32\\tar.exe",
 	])
 	do_return(possible_windows_paths).on(update)._list_installed_tar_paths()
 	# on windows we want to find the windows provided tar version
@@ -81,7 +83,9 @@ func test_find_tar_path_on_windows() -> void:
 	
 	# Windows is installed on D:
 	possible_windows_paths = PoolStringArray([
-		"C:\\my_tar\\tar.exe\nD:\\tools\\tar.exe\nD:\\Windows\\System32\\tar.exe",
+		"C:\\my_tar\\tar.exe",
+		"D:\\tools\\tar.exe",
+		"D:\\Windows\\System32\\tar.exe",
 	])
 	do_return(possible_windows_paths).on(update)._list_installed_tar_paths()
 	assert_str(update._find_tar_path("Windows")).is_equal("D:\\Windows\\System32\\tar.exe")
@@ -89,3 +93,16 @@ func test_find_tar_path_on_windows() -> void:
 func test_find_tar_path_on_non_windows() -> void:
 	assert_str(GdUnitUpdate._find_tar_path("MacOS")).is_equal("tar")
 	assert_str(GdUnitUpdate._find_tar_path("X11")).is_equal("tar")
+
+
+func test_paths():
+	var stdout = Array()
+	OS.execute("where", ["tar"], true, stdout)
+	prints("size:", stdout.size(), stdout)
+	var path :String = stdout[0]
+	
+	var paths = path.split("\n")
+	
+	prints(paths)
+	for p in paths:
+		prints("element:", "`%s`" % p)


### PR DESCRIPTION

- The unpack by tool `tar` was failing if multible tar version installed.
  Fixed by lookup and use the full path for windows provided tar tool