### PR TITLE
GD-133: Improve the value extractor `extr` to support function name chaining

### DIFF
--- a/addons/gdUnit3/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit3/src/GdUnitTestSuite.gd
@@ -255,7 +255,7 @@ static func any_class(clazz :Object) -> GdUnitArgumentMatcher:
 # === value extract utils ======================================================
 # Builds an extractor by given function name and optional arguments
 static func extr(func_name :String, args := Array()) -> GdUnitValueExtractor:
-	return GdUnitValueExtractor.new(func_name, args)
+	return GdUnitFuncValueExtractor.new(func_name, args)
 
 # Constructs a tuple by given arguments
 static func tuple(arg0, arg1=GdUnitTuple.NO_ARG, arg2=GdUnitTuple.NO_ARG, arg3=GdUnitTuple.NO_ARG, arg4=GdUnitTuple.NO_ARG, arg5=GdUnitTuple.NO_ARG, arg6=GdUnitTuple.NO_ARG, arg7=GdUnitTuple.NO_ARG, arg8=GdUnitTuple.NO_ARG, arg9=GdUnitTuple.NO_ARG) -> GdUnitTuple:

--- a/addons/gdUnit3/src/GdUnitValueExtractor.gd
+++ b/addons/gdUnit3/src/GdUnitValueExtractor.gd
@@ -1,40 +1,8 @@
-# This class defines a value extractor by given name and args
+# This is the base interface for value extraction
 class_name GdUnitValueExtractor
 extends Reference
 
-var _func_name :String
-var _args :Array
-
-func _init(func_name :String, args :Array):
-	_func_name = func_name
-	_args = args
-
-func func_name() -> String:
-	return _func_name
-
-func args() -> Array:
-	return _args
-
-# extracts a value by given `func_name` and `args`,
-# if the value not a Object or not accesible be `func_name` the value is converted to `"n.a."`
-# expecing null values
+# Extracts a value by given implementation
 func extract_value(value):
-	if value == null:
-		return null
-	
-	# for array types we need to call explicit by function name, using funcref is only supported for Objects
-	# TODO extend to all array functions
-	if GdObjects.is_array_type(value) and func_name() == "empty":
-		return value.empty()
-	
-	if not (value is Object):
-		if GdUnitSettings.is_verbose_assert_warnings():
-			push_warning("Extracting value from element '%s' by func '%s' failed! Converting to \"n.a.\"" % [value, func_name()])
-		return "n.a."
-	var extract := funcref(value, func_name())
-	if extract.is_valid():
-		return value.call(func_name()) if args().empty() else value.callv(func_name(), args())
-	else:
-		if GdUnitSettings.is_verbose_assert_warnings():
-			push_warning("Extracting value from element '%s' by func '%s' failed! Converting to \"n.a.\"" % [value, func_name()])
-		return "n.a."
+	push_error("Uninplemented func 'extract_value'")
+	return value

--- a/addons/gdUnit3/src/asserts/GdUnitArrayAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitArrayAssertImpl.gd
@@ -180,7 +180,7 @@ func is_instanceof(expected) -> GdUnitAssert:
 # extracts all values by given function name or null if not exists
 func extract(func_name :String, args := Array()) -> GdUnitArrayAssert:
 	var extracted_elements: = Array()
-	var extractor := GdUnitValueExtractor.new(func_name, args)
+	var extractor := GdUnitFuncValueExtractor.new(func_name, args)
 	for element in __current():
 		extracted_elements.append(extractor.extract_value(element))
 	_base._current = extracted_elements

--- a/addons/gdUnit3/src/extractors/GdUnitFuncValueExtractor.gd
+++ b/addons/gdUnit3/src/extractors/GdUnitFuncValueExtractor.gd
@@ -1,0 +1,59 @@
+# This class defines a value extractor by given function name and args
+class_name GdUnitFuncValueExtractor
+extends GdUnitValueExtractor
+
+var _func_names :Array
+var _args :Array
+
+func _init(func_name :String, args :Array):
+	_func_names = func_name.split(".")
+	_args = args
+
+func func_names() -> Array:
+	return _func_names
+
+func args() -> Array:
+	return _args
+
+# Extracts a value by given `func_name` and `args`,
+# Allows to use a chained list of functions setarated ba a dot. 
+#  e.g. "func_a.func_b.name"
+#  do calls instance.func_a().func_b().name() and returns finally the name
+# If a function returns an array, all elements will by collected in a array
+#  e.g. "get_children.get_name" on a node
+#  do calls node.get_children() for all childs get_name() and returns all names in an array
+#
+# if the value not a Object or not accesible be `func_name` the value is converted to `"n.a."`
+# expecing null values
+func extract_value(value):
+	if value == null:
+		return null
+	for func_name in func_names():
+		if GdObjects.is_array_type(value):
+			var values := Array()
+			for element in Array(value):
+				values.append(_call_func(element, func_name))
+			value = values
+		else:
+			value = _call_func(value, func_name)
+		if typeof(value) == TYPE_STRING and value == "n.a.":
+			return value
+	return value
+
+func _call_func(value, func_name :String):
+	# for array types we need to call explicit by function name, using funcref is only supported for Objects
+	# TODO extend to all array functions
+	if GdObjects.is_array_type(value) and func_name == "empty":
+		return value.empty()
+	
+	if not (value is Object):
+		if GdUnitSettings.is_verbose_assert_warnings():
+			push_warning("Extracting value from element '%s' by func '%s' failed! Converting to \"n.a.\"" % [value, func_name])
+		return "n.a."
+	var extract := funcref(value, func_name)
+	if extract.is_valid():
+		return value.call(func_name) if args().empty() else value.callv(func_name, args())
+	else:
+		if GdUnitSettings.is_verbose_assert_warnings():
+			push_warning("Extracting value from element '%s' by func '%s' failed! Converting to \"n.a.\"" % [value, func_name])
+		return "n.a."

--- a/addons/gdUnit3/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -242,6 +242,44 @@ func test_extractv() -> void:
 		.extractv(extr("get_name"), extr("get_value"), extr("get_x"))\
 		.contains_exactly([tuple("A", 10, null), tuple("B", "foo", "bar"), tuple("C", 11, 42)])
 
+func test_extractv_chained_func() -> void:
+	var root_a = TestObj.new("root_a", null)
+	var obj_a = TestObj.new("A", root_a)
+	var obj_b = TestObj.new("B", root_a)
+	var obj_c = TestObj.new("C", root_a)
+	var root_b = TestObj.new("root_b", root_a)
+	var obj_x = TestObj.new("X", root_b)
+	var obj_y = TestObj.new("Y", root_b)
+	
+	assert_array([obj_a, obj_b, obj_c, obj_x, obj_y])\
+		.extractv(extr("get_name"), extr("get_value.get_name"))\
+		.contains_exactly([
+			tuple("A", "root_a"),
+			tuple("B", "root_a"),
+			tuple("C", "root_a"),
+			tuple("X", "root_b"),
+			tuple("Y", "root_b")
+			])
+
+func test_extract_chained_func() -> void:
+	var root_a = TestObj.new("root_a", null)
+	var obj_a = TestObj.new("A", root_a)
+	var obj_b = TestObj.new("B", root_a)
+	var obj_c = TestObj.new("C", root_a)
+	var root_b = TestObj.new("root_b", root_a)
+	var obj_x = TestObj.new("X", root_b)
+	var obj_y = TestObj.new("Y", root_b)
+	
+	assert_array([obj_a, obj_b, obj_c, obj_x, obj_y])\
+		.extract("get_value.get_name")\
+		.contains_exactly([
+			"root_a",
+			"root_a",
+			"root_a",
+			"root_b",
+			"root_b",
+			])
+
 func test_extractv_max_args() -> void:
 		assert_array([TestObj.new("A", 10), TestObj.new("B", "foo", "bar"), TestObj.new("C", 11, 42)])\
 		.extractv(\

--- a/addons/gdUnit3/test/extractors/GdUnitFuncValueExtractorTest.gd
+++ b/addons/gdUnit3/test/extractors/GdUnitFuncValueExtractorTest.gd
@@ -1,0 +1,57 @@
+# GdUnit generated TestSuite
+class_name GdUnitFuncValueExtractorTest
+extends GdUnitTestSuite
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit3/src/extractors/GdUnitFuncValueExtractor.gd'
+
+class TestNode:
+	var _name :String
+	var _parent :TestNode = null
+	var _children := Array()
+	
+	func _init(name :String, parent :TestNode = null):
+		_name = name
+		_parent = parent
+		if _parent:
+			_parent._children.append(self)
+	
+	func get_name() -> String:
+		return _name
+	
+	func get_parent() -> TestNode:
+		return _parent
+	
+	func get_children() -> Array:
+		return _children
+	
+
+func test_extract_value_success() -> void:
+	var node = TestNode.new("node_a")
+	
+	assert_str(GdUnitFuncValueExtractor.new("get_name", []).extract_value(node)).is_equal("node_a")
+
+func test_extract_value_func_not_exists() -> void:
+	var node = TestNode.new("node_a")
+	
+	assert_str(GdUnitFuncValueExtractor.new("get_foo", []).extract_value(node)).is_equal("n.a.")
+
+func test_extract_value_on_null_value() -> void:
+	assert_str(GdUnitFuncValueExtractor.new("get_foo", []).extract_value(null)).is_null()
+
+
+func test_extract_value_chanined() -> void:
+	var parent = TestNode.new("parent")
+	var node = TestNode.new("node_a", parent)
+	
+	assert_str(GdUnitFuncValueExtractor.new("get_name", []).extract_value(node)).is_equal("node_a")
+	assert_str(GdUnitFuncValueExtractor.new("get_parent.get_name", []).extract_value(node)).is_equal("parent")
+
+func test_extract_value_chanined_array_values() -> void:
+	var parent = TestNode.new("parent")
+	TestNode.new("node_a", parent)
+	TestNode.new("node_b", parent)
+	TestNode.new("node_c", parent)
+	
+	assert_array(GdUnitFuncValueExtractor.new("get_children.get_name", []).extract_value(parent))\
+		.contains_exactly(["node_a", "node_b", "node_c"])

--- a/project.godot
+++ b/project.godot
@@ -419,6 +419,16 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gdUnit3/test/asserts/GdUnitFloatAssertImplTest.gd"
 }, {
+"base": "GdUnitValueExtractor",
+"class": "GdUnitFuncValueExtractor",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/src/extractors/GdUnitFuncValueExtractor.gd"
+}, {
+"base": "GdUnitTestSuite",
+"class": "GdUnitFuncValueExtractorTest",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/test/extractors/GdUnitFuncValueExtractorTest.gd"
+}, {
 "base": "Reference",
 "class": "GdUnitHtmlPatterns",
 "language": "GDScript",
@@ -1022,6 +1032,8 @@ _global_script_class_icons={
 "GdUnitFloatAssert": "",
 "GdUnitFloatAssertImpl": "",
 "GdUnitFloatAssertImplTest": "",
+"GdUnitFuncValueExtractor": "",
+"GdUnitFuncValueExtractorTest": "",
 "GdUnitHtmlPatterns": "",
 "GdUnitHtmlReport": "",
 "GdUnitInit": "",


### PR DESCRIPTION
- moved implementation from `GdUnitValueExtractor` to `GdUnitFuncValueExtractor` and convert to an interface
- added function name chaining on `extr` func
- added function name chaining on ArrayAssert:extract and extractv