### PR TITLE
GD-144: Fix Godot crash on MacOS when closing

### DIFF
--- a/addons/gdUnit3/plugin.cfg
+++ b/addons/gdUnit3/plugin.cfg
@@ -3,5 +3,5 @@
 name="gdUnit3"
 description="Unit Testing Framework for Godot Scripts"
 author="Mike Schulze"
-version="1.0.4"
+version="1.0.5"
 script="plugin.gd"

--- a/addons/gdUnit3/plugin.gd
+++ b/addons/gdUnit3/plugin.gd
@@ -41,9 +41,10 @@ func _exit_tree():
 	_gd_inspector.free()
 	_gd_console.free()
 	_server_node.free()
-	 # Delete and release the update tool only when it is not in use, otherwise it will interrupt the execution of the update
+	# Delete and release the update tool only when it is not in use, otherwise it will interrupt the execution of the update
 	if _update_tool and not _update_tool.is_update_in_progress():
-		remove_child(_update_tool)
+		get_parent().call_deferred("remove_child", _update_tool)
+		yield(get_tree(), "idle_frame")
 		_update_tool.free()
 	GdUnitSingleton.remove_singleton(SignalHandler.SINGLETON_NAME)
 	Engine.remove_meta("GdUnitEditorPlugin")


### PR DESCRIPTION
- Godot was crashing on MacOS because of invalid removing `_update_tool`