### PR TITLE
GD-166: Fixed a error is raised when spying a script that preloads another script

### DIFF
--- a/addons/gdUnit3/src/asserts/GdAssertReports.gd
+++ b/addons/gdUnit3/src/asserts/GdAssertReports.gd
@@ -2,6 +2,7 @@ class_name GdAssertReports
 extends Reference
 
 const LAST_ERROR = "last_assert_error_message"
+const LAST_ERROR_LINE = "last_assert_error_line"
 
 # if a test success but we expect to fail map to an error
 static func report_success(gd_assert :GdUnitAssert) -> GdUnitAssert:
@@ -23,3 +24,14 @@ static func report_error(message:String, gd_assert :GdUnitAssert, line_number :i
 			return gd_assert
 	gd_assert.send_report(GdUnitReport.new().create(GdUnitReport.FAILURE, line_number, message))
 	return gd_assert
+
+static func reset_last_error_line_number() -> void:
+	Engine.remove_meta(LAST_ERROR_LINE)
+
+static func set_last_error_line_number(line_number :int) -> void:
+	Engine.set_meta(LAST_ERROR_LINE, line_number)
+
+static func get_last_error_line_number() -> int:
+	if Engine.has_meta(LAST_ERROR_LINE):
+		return Engine.get_meta(LAST_ERROR_LINE)
+	return -1

--- a/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
@@ -16,7 +16,7 @@ static func _get_line_number() -> int:
 	for stack_info in stack_trace:
 		var function :String = stack_info.get("function")
 		var source :String = stack_info.get("source")
-		if source.ends_with("AssertImpl.gd") or source.ends_with("GdUnitTestSuite.gd"):
+		if source.empty() or source.ends_with("AssertImpl.gd") or source.ends_with("GdUnitTestSuite.gd"):
 			continue
 		return stack_info.get("line")
 	return -1
@@ -26,6 +26,7 @@ func _init(caller :Object, current, expect_result :int = EXPECT_SUCCESS):
 	assert(caller.has_meta(GdUnitReportConsumer.META_PARAM), "caller must register a report consumer!")
 	_report_consumer = weakref(caller.get_meta(GdUnitReportConsumer.META_PARAM))
 	_current_value_provider = current if current is ValueProvider else DefaultValueProvider.new(current)
+	GdAssertReports.reset_last_error_line_number()
 	# we expect the test will fail
 	if expect_result == EXPECT_FAIL:
 		_expect_fail = true
@@ -41,6 +42,7 @@ func report_success() -> GdUnitAssert:
 
 func report_error(error_message :String) -> GdUnitAssert:
 	var line_number := _get_line_number()
+	GdAssertReports.set_last_error_line_number(line_number)
 	if _custom_failure_message == null:
 		return GdAssertReports.report_error(error_message, self, line_number)
 	return GdAssertReports.report_error(_custom_failure_message, self, line_number)

--- a/addons/gdUnit3/src/asserts/GdUnitFuncAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitFuncAssertImpl.gd
@@ -21,6 +21,7 @@ func _init(caller :WeakRef, instance :Object, func_name :String, args := Array()
 	_line_number = GdUnitAssertImpl._get_line_number()
 	_expect_result = expect_result
 	_caller = caller
+	GdAssertReports.reset_last_error_line_number()
 	# set report consumer to be use to report the final result
 	_report_consumer = caller.get_ref().get_meta(GdUnitReportConsumer.META_PARAM)
 	# we expect the test will fail

--- a/addons/gdUnit3/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitSignalAssertImpl.gd
@@ -24,6 +24,7 @@ func _init(caller :WeakRef, instance :Object, expect_result := EXPECT_SUCCESS):
 	_caller = caller
 	_instance =  instance
 	_expect_result = expect_result
+	GdAssertReports.reset_last_error_line_number()
 	# set report consumer to be use to report the final result
 	_report_consumer = caller.get_ref().get_meta(GdUnitReportConsumer.META_PARAM)
 	# we expect the test will fail

--- a/addons/gdUnit3/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit3/src/core/parse/GdScriptParser.gd
@@ -509,7 +509,8 @@ func load_source_code(script :GDScript, script_path :PoolStringArray) -> PoolStr
 		var value = map.get(key)
 		if value is GDScript:
 			var class_path := GdObjects.extract_class_path(value)
-			_scanned_inner_classes.append(class_path[1])
+			if class_path.size() > 1:
+				_scanned_inner_classes.append(class_path[1])
 
 	var source_code := to_unix_format(script.source_code)
 	var source_rows := source_code.split("\n")

--- a/addons/gdUnit3/test/asserts/GdUnitAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitAssertImplTest.gd
@@ -9,28 +9,39 @@ func before():
 	assert_int(GdUnitAssertImpl._get_line_number()).is_equal(9)
 
 func after():
-	assert_int(GdUnitAssertImpl._get_line_number()).is_equal(12)
+	assert_int(10, GdUnitAssert.EXPECT_FAIL).is_equal(42)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(12)
 
 func before_test():
-	assert_int(GdUnitAssertImpl._get_line_number()).is_equal(15)
+	assert_int(10, GdUnitAssert.EXPECT_FAIL).is_equal(42)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(16)
 
 func after_test():
-	assert_int(GdUnitAssertImpl._get_line_number()).is_equal(18)
+	assert_int(10, GdUnitAssert.EXPECT_FAIL).is_equal(42)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(20)
 
 func test_get_line_number():
 	# test to return the current line number for an failure
-	assert_int(GdUnitAssertImpl._get_line_number()).is_equal(22)
+	assert_int(10, GdUnitAssert.EXPECT_FAIL).is_equal(42)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(25)
 
 func test_get_line_number_yielded():
 	# test to return the current line number after using yield
 	yield(get_tree().create_timer(0.100), "timeout")
-	assert_int(GdUnitAssertImpl._get_line_number()).is_equal(27)
+	assert_int(10, GdUnitAssert.EXPECT_FAIL).is_equal(42)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(31)
 
 func test_get_line_number_multiline():
 	# test to return the current line number for an failure
 	# https://github.com/godotengine/godot/issues/43326
-	assert_int(GdUnitAssertImpl\
-		._get_line_number()).is_equal(32)
+	assert_int(10, GdUnitAssert.EXPECT_FAIL).is_not_negative()\
+		.is_equal(42)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(37)
+
+func test_get_line_number_verify():
+	var obj = mock(Reference)
+	verify(obj, 1, GdUnitAssert.EXPECT_FAIL)._to_string()
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(43)
 
 func test_is_null():
 	assert_that(null).is_null()

--- a/addons/gdUnit3/test/resources/issues/gd-166/issue.gd
+++ b/addons/gdUnit3/test/resources/issues/gd-166/issue.gd
@@ -1,0 +1,11 @@
+extends Object
+
+const Type = preload("types.gd")
+
+var type = null setget _set_type
+var type_name
+	
+func _set_type(t:int):
+	type = t
+	type_name = Type.to_str(t)
+	print("type was set to %s" % type_name)

--- a/addons/gdUnit3/test/resources/issues/gd-166/types.gd
+++ b/addons/gdUnit3/test/resources/issues/gd-166/types.gd
@@ -1,0 +1,9 @@
+extends Object
+
+enum { FOO, BAR, BAZ }
+
+static func to_str(type:int):
+	match type:
+		FOO: return "FOO"
+		BAR: return "BAR"
+		BAZ: return "BAZ"

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -307,6 +307,18 @@ func test_spy_snake_case_named_class_by_class():
 	verify(spy_tcp_server).is_connection_available()
 	verify_no_more_interactions(spy_tcp_server)
 
+const Issue = preload("res://addons/gdUnit3/test/resources/issues/gd-166/issue.gd")
+const Type = preload("res://addons/gdUnit3/test/resources/issues/gd-166/types.gd")
+
+func test_spy_preload_class_GD_166() -> void:
+	var instance = auto_free(Issue.new())
+	var spy_instance = spy(instance)
+	
+	spy_instance.type = Type.FOO
+	verify(spy_instance, 1)._set_type(Type.FOO)
+	assert_int(spy_instance.type).is_equal(Type.FOO)
+	assert_str(spy_instance.type_name).is_equal("FOO")
+
 var _test_signal_is_emited := false
 func _emit_ready(a, b, c):
 	prints("_emit_ready", a, b, c)


### PR DESCRIPTION

- fix wrong line error detection for `verify`