### PR TITLE
GD-168: Add `is_failure` on test-suite to reflect current test state.

### DIFF
--- a/addons/gdUnit3/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit3/src/GdUnitTestSuite.gd
@@ -38,6 +38,9 @@ func after_test() -> void:
 func skip(skipped :bool) -> void:
 	set_meta("gd_skipped", skipped)
 
+func is_failure() -> bool:
+	return get_meta(GdUnitAssertImpl.GD_TEST_FAILURE) if has_meta(GdUnitAssertImpl.GD_TEST_FAILURE) else false
+
 func is_skipped() -> bool:
 	return get_meta("gd_skipped") if has_meta("gd_skipped") else false
 

--- a/addons/gdUnit3/src/core/GdUnitExecutor.gd
+++ b/addons/gdUnit3/src/core/GdUnitExecutor.gd
@@ -119,6 +119,7 @@ func test_before(test_suite :GdUnitTestSuite, test_case :_TestCase) -> GDScriptF
 	fire_event(GdUnitEvent.new()\
 		.test_before(test_suite.get_script().resource_path, test_suite.get_name(), test_case.get_name()))
 	
+	test_suite.set_meta(GdUnitAssertImpl.GD_TEST_FAILURE, false)
 	if not test_case.is_skipped():
 		var fstate = test_suite.before_test()
 		if GdUnitTools.is_yielded(fstate):

--- a/addons/gdUnit3/test/asserts/GdUnitArrayAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitArrayAssertImplTest.gd
@@ -312,3 +312,26 @@ func next_value() -> Array:
 func test_with_value_provider() -> void:
 	assert_array(CallBackValueProvider.new(self, "next_value"))\
 		.is_equal([1]).is_equal([2]).is_equal([3])
+
+# tests if an assert fails the 'is_failure' reflects the failure status
+func test_is_failure() -> void:
+	# initial is false
+	assert_bool(is_failure()).is_false()
+	
+	# on success assert
+	assert_array([]).is_empty()
+	assert_bool(is_failure()).is_false()
+	
+	# on faild assert
+	assert_array([], GdUnitAssert.EXPECT_FAIL).is_not_empty()
+	assert_bool(is_failure()).is_true()
+	
+	# on next success assert
+	assert_array([]).is_empty()
+	# is true because we have an already failed assert
+	assert_bool(is_failure()).is_true()
+	
+	# should abort here because we had an failing assert
+	if is_failure():
+		return
+	assert_bool(true).override_failure_message("This line shold never be called").is_false()

--- a/addons/gdUnit3/test/asserts/GdUnitBoolAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitBoolAssertImplTest.gd
@@ -70,3 +70,26 @@ func next_value() -> bool:
 func test_with_value_provider() -> void:
 	assert_bool(CallBackValueProvider.new(self, "next_value"))\
 		.is_true().is_false().is_false()
+
+# tests if an assert fails the 'is_failure' reflects the failure status
+func test_is_failure() -> void:
+	# initial is false
+	assert_bool(is_failure()).is_false()
+	
+	# on success assert
+	assert_bool(true).is_true()
+	assert_bool(is_failure()).is_false()
+	
+	# on faild assert
+	assert_bool(true, GdUnitAssert.EXPECT_FAIL).is_false()
+	assert_bool(is_failure()).is_true()
+	
+	# on next success assert
+	assert_bool(true).is_true()
+	# is true because we have an already failed assert
+	assert_bool(is_failure()).is_true()
+	
+	# should abort here because we had an failing assert
+	if is_failure():
+		return
+	assert_bool(true).override_failure_message("This line shold never be called").is_false()

--- a/addons/gdUnit3/test/asserts/GdUnitDictionaryAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitDictionaryAssertImplTest.gd
@@ -170,3 +170,26 @@ func next_value() -> Dictionary:
 func test_with_value_provider() -> void:
 	assert_dict(CallBackValueProvider.new(self, "next_value"))\
 		.is_equal({"key_1" : 1}).is_equal({"key_2" : 2}).is_equal({"key_3" : 3})
+
+# tests if an assert fails the 'is_failure' reflects the failure status
+func test_is_failure() -> void:
+	# initial is false
+	assert_bool(is_failure()).is_false()
+	
+	# on success assert
+	assert_dict({}).is_empty()
+	assert_bool(is_failure()).is_false()
+	
+	# on faild assert
+	assert_dict({}, GdUnitAssert.EXPECT_FAIL).is_not_empty()
+	assert_bool(is_failure()).is_true()
+	
+	# on next success assert
+	assert_dict({}).is_empty()
+	# is true because we have an already failed assert
+	assert_bool(is_failure()).is_true()
+	
+	# should abort here because we had an failing assert
+	if is_failure():
+		return
+	assert_bool(true).override_failure_message("This line shold never be called").is_false()

--- a/addons/gdUnit3/test/asserts/GdUnitFloatAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitFloatAssertImplTest.gd
@@ -161,3 +161,26 @@ func next_value() -> float:
 func test_with_value_provider() -> void:
 	assert_float(CallBackValueProvider.new(self, "next_value"))\
 		.is_equal(1.1).is_equal(2.2)
+
+# tests if an assert fails the 'is_failure' reflects the failure status
+func test_is_failure() -> void:
+	# initial is false
+	assert_bool(is_failure()).is_false()
+	
+	# on success assert
+	assert_float(0.0).is_zero()
+	assert_bool(is_failure()).is_false()
+	
+	# on faild assert
+	assert_float(1.0, GdUnitAssert.EXPECT_FAIL).is_zero()
+	assert_bool(is_failure()).is_true()
+	
+	# on next success assert
+	assert_float(0.0).is_zero()
+	# is true because we have an already failed assert
+	assert_bool(is_failure()).is_true()
+	
+	# should abort here because we had an failing assert
+	if is_failure():
+		return
+	assert_bool(true).override_failure_message("This line shold never be called").is_false()

--- a/addons/gdUnit3/test/asserts/GdUnitIntAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitIntAssertImplTest.gd
@@ -160,3 +160,26 @@ func next_value() -> int:
 func test_with_value_provider() -> void:
 	assert_int(CallBackValueProvider.new(self, "next_value"))\
 		.is_equal(1).is_equal(2).is_equal(3)
+
+# tests if an assert fails the 'is_failure' reflects the failure status
+func test_is_failure() -> void:
+	# initial is false
+	assert_bool(is_failure()).is_false()
+	
+	# on success assert
+	assert_int(0).is_zero()
+	assert_bool(is_failure()).is_false()
+	
+	# on faild assert
+	assert_int(1, GdUnitAssert.EXPECT_FAIL).is_zero()
+	assert_bool(is_failure()).is_true()
+	
+	# on next success assert
+	assert_int(0).is_zero()
+	# is true because we have an already failed assert
+	assert_bool(is_failure()).is_true()
+	
+	# should abort here because we had an failing assert
+	if is_failure():
+		return
+	assert_bool(true).override_failure_message("This line shold never be called").is_false()

--- a/addons/gdUnit3/test/asserts/GdUnitObjectAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitObjectAssertImplTest.gd
@@ -117,3 +117,26 @@ func next_value() -> Object:
 func test_with_value_provider() -> void:
 	assert_object(CallBackValueProvider.new(self, "next_value"))\
 		.is_equal(_values[0]).is_equal(_values[1]).is_equal(_values[2])
+
+# tests if an assert fails the 'is_failure' reflects the failure status
+func test_is_failure() -> void:
+	# initial is false
+	assert_bool(is_failure()).is_false()
+	
+	# on success assert
+	assert_object(null).is_null()
+	assert_bool(is_failure()).is_false()
+	
+	# on faild assert
+	assert_object(Reference.new(), GdUnitAssert.EXPECT_FAIL).is_null()
+	assert_bool(is_failure()).is_true()
+	
+	# on next success assert
+	assert_object(null).is_null()
+	# is true because we have an already failed assert
+	assert_bool(is_failure()).is_true()
+	
+	# should abort here because we had an failing assert
+	if is_failure():
+		return
+	assert_bool(true).override_failure_message("This line shold never be called").is_false()

--- a/addons/gdUnit3/test/asserts/GdUnitResultAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitResultAssertImplTest.gd
@@ -107,3 +107,21 @@ func next_value() -> Result:
 func test_with_value_provider() -> void:
 	assert_result(CallBackValueProvider.new(self, "next_value"))\
 		.is_success().is_error().is_warning()
+
+# tests if an assert fails the 'is_failure' reflects the failure status
+func test_is_failure() -> void:
+	# initial is false
+	assert_bool(is_failure()).is_false()
+	
+	# on success assert
+	assert_result(null).is_null()
+	assert_bool(is_failure()).is_false()
+	
+	# on faild assert
+	assert_result(Reference.new(), GdUnitAssert.EXPECT_FAIL).is_null()
+	assert_bool(is_failure()).is_true()
+	
+	# on next success assert
+	assert_result(null).is_null()
+	# is true because we have an already failed assert
+	assert_bool(is_failure()).is_true()

--- a/addons/gdUnit3/test/asserts/GdUnitStringAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitStringAssertImplTest.gd
@@ -192,3 +192,21 @@ func next_value() -> String:
 func test_with_value_provider() -> void:
 	assert_str(CallBackValueProvider.new(self, "next_value"))\
 		.is_equal("value_1").is_equal("value_2").is_equal("value_3")
+
+# tests if an assert fails the 'is_failure' reflects the failure status
+func test_is_failure() -> void:
+	# initial is false
+	assert_bool(is_failure()).is_false()
+	
+	# on success assert
+	assert_str(null).is_null()
+	assert_bool(is_failure()).is_false()
+	
+	# on faild assert
+	assert_str(Reference.new(), GdUnitAssert.EXPECT_FAIL).is_null()
+	assert_bool(is_failure()).is_true()
+	
+	# on next success assert
+	assert_str(null).is_null()
+	# is true because we have an already failed assert
+	assert_bool(is_failure()).is_true()

--- a/addons/gdUnit3/test/asserts/GdUnitVector2AssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitVector2AssertImplTest.gd
@@ -137,3 +137,21 @@ func next_value() -> Vector2:
 func test_with_value_provider() -> void:
 	assert_vector2(CallBackValueProvider.new(self, "next_value"))\
 		.is_equal(Vector2.ZERO).is_equal(Vector2.ONE).is_equal(Vector2.INF)
+
+# tests if an assert fails the 'is_failure' reflects the failure status
+func test_is_failure() -> void:
+	# initial is false
+	assert_bool(is_failure()).is_false()
+	
+	# on success assert
+	assert_vector2(null).is_null()
+	assert_bool(is_failure()).is_false()
+	
+	# on faild assert
+	assert_vector2(Reference.new(), GdUnitAssert.EXPECT_FAIL).is_null()
+	assert_bool(is_failure()).is_true()
+	
+	# on next success assert
+	assert_vector2(null).is_null()
+	# is true because we have an already failed assert
+	assert_bool(is_failure()).is_true()

--- a/addons/gdUnit3/test/asserts/GdUnitVector3AssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitVector3AssertImplTest.gd
@@ -137,3 +137,21 @@ func next_value() -> Vector2:
 func test_with_value_provider() -> void:
 	assert_vector3(CallBackValueProvider.new(self, "next_value"))\
 		.is_equal(Vector3.ZERO).is_equal(Vector3.ONE).is_equal(Vector3.INF)
+
+# tests if an assert fails the 'is_failure' reflects the failure status
+func test_is_failure() -> void:
+	# initial is false
+	assert_bool(is_failure()).is_false()
+	
+	# on success assert
+	assert_vector3(null).is_null()
+	assert_bool(is_failure()).is_false()
+	
+	# on faild assert
+	assert_vector3(Reference.new(), GdUnitAssert.EXPECT_FAIL).is_null()
+	assert_bool(is_failure()).is_true()
+	
+	# on next success assert
+	assert_vector3(null).is_null()
+	# is true because we have an already failed assert
+	assert_bool(is_failure()).is_true()


### PR DESCRIPTION
- GdScript has no valid function to abort an processing script like an exception.
  To allow to abort fast i introduce 'is_failure' on test-suite to use to abort the
  current running test by checking `if `is_failure`():`