### PR TITLE
GD-185: Fix RichTextEffectBackground diff visualisation for indent lines

### DIFF
--- a/addons/gdUnit3/src/ui/GdUnitConsole.gd
+++ b/addons/gdUnit3/src/ui/GdUnitConsole.gd
@@ -24,6 +24,7 @@ func _ready():
 	_signal_handler.register_on_client_disconnected(self, "_on_client_disconnected")
 	header.bbcode_text = TITLE.replace('${version}', version)
 	output.clear()
+	output.setup_effects()
 
 func _notification(what):
 	if what == EditorSettings.NOTIFICATION_EDITOR_SETTINGS_CHANGED:
@@ -67,30 +68,36 @@ func _on_event_test_suite(event :GdUnitEvent):
 			output.append_bbcode(" %+12s" % LocalTime.elapsed(event.elapsed_time()))
 			output.newline()
 			output.push_color(_text_color.to_html())
-			output.append_bbcode("	| %d total | %d error | %d failed | %d skipped | %d orphans |\n" % [_statistics["total_count"], _statistics["error_count"], _statistics["failed_count"], _statistics["skipped_count"], _statistics["orphan_nodes"]])
+			output.push_indent(1)
+			output.append_bbcode("| %d total | %d error | %d failed | %d skipped | %d orphans |\n" % [_statistics["total_count"], _statistics["error_count"], _statistics["failed_count"], _statistics["skipped_count"], _statistics["orphan_nodes"]])
+			output.pop_indent(1)
 			output.pop()
 			output.newline()
 		GdUnitEvent.TESTCASE_BEFORE:
 			var spaces = "-%d" % (80 - event._suite_name.length())
-			output.append_bbcode(("\t[color=#" + _engine_type_color.to_html() + "]%s[/color]:[color=#" + _function_color.to_html() + "]%"+spaces+"s[/color]") % [event._suite_name, event._test_name])
+			output.push_indent(1)
+			output.append_bbcode(("[color=#" + _engine_type_color.to_html() + "]%s[/color]:[color=#" + _function_color.to_html() + "]%"+spaces+"s[/color]") % [event._suite_name, event._test_name])
+			output.pop_indent(1)
 		GdUnitEvent.TESTCASE_AFTER:
 			var reports := event.reports()
 			update_statistics(event)
 			if event.is_success():
 				output.push_color(Color.lightgreen.to_html())
 				output.append_bbcode("PASSED")
+				output.pop()
+				output.append_bbcode(" %+12s" % LocalTime.elapsed(event.elapsed_time()))
 			else:
 				output.push_color(Color.firebrick.to_html())
 				var report:GdUnitReport = reports[0]
 				output.append_bbcode("FAILED")
+				output.pop()
+				output.append_bbcode(" %+12s" % LocalTime.elapsed(event.elapsed_time()))
 				output.newline()
 				output.push_color(_text_color.to_html())
 				output.push_indent(2)
 				output.append_bbcode("line %d %s" % [report._line_number, report._message])
+				output.pop_indent(2)
 				output.pop()
-				output.pop()
-			output.pop()
-			output.append_bbcode(" %+12s" % LocalTime.elapsed(event.elapsed_time()))
 			output.newline()
 
 func _on_client_connected(client_id :int) -> void:

--- a/addons/gdUnit3/src/ui/GdUnitConsole.tscn
+++ b/addons/gdUnit3/src/ui/GdUnitConsole.tscn
@@ -1,16 +1,22 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://addons/gdUnit3/src/ui/GdUnitConsole.gd" type="Script" id=1]
 [ext_resource path="res://addons/gdUnit3/src/update/assets/fonts/RobotoMono-14-bold-italics.tres" type="DynamicFont" id=2]
 [ext_resource path="res://addons/gdUnit3/src/update/assets/fonts/RobotoMono-14.tres" type="DynamicFont" id=3]
 [ext_resource path="res://addons/gdUnit3/src/update/assets/fonts/RobotoMono-14-italics.tres" type="DynamicFont" id=4]
 [ext_resource path="res://addons/gdUnit3/src/update/assets/fonts/RobotoMono-14-bold.tres" type="DynamicFont" id=5]
+[ext_resource path="res://addons/gdUnit3/src/ui/parts/RichTextLabelExt.gd" type="Script" id=6]
+[ext_resource path="res://addons/gdUnit3/src/ui/parts/RichTextEffectBackground.gd" type="Script" id=7]
+
+[sub_resource type="RichTextEffect" id=1]
+script = ExtResource( 7 )
 
 [node name="Control" type="Control"]
 use_parent_material = true
 anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 0, 100 )
+rect_clip_content = true
 script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -20,6 +26,9 @@ __meta__ = {
 use_parent_material = true
 anchor_right = 1.0
 anchor_bottom = 1.0
+rect_clip_content = true
+size_flags_horizontal = 3
+size_flags_vertical = 3
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -61,6 +70,8 @@ custom_fonts/bold_font = ExtResource( 5 )
 custom_fonts/normal_font = ExtResource( 3 )
 bbcode_enabled = true
 scroll_following = true
+custom_effects = [ SubResource( 1 ) ]
+script = ExtResource( 6 )
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/addons/gdUnit3/src/ui/parts/RichTextEffectBackground.gd
+++ b/addons/gdUnit3/src/ui/parts/RichTextEffectBackground.gd
@@ -1,6 +1,9 @@
-# Custom background color effect (c)2021 Mike Schulze
-# This effect works currently only for mono fonts
-tool
+# This effect works currently only with mono fonts
+
+# MIT License
+# Copyright (c) 2020 Mike Schulze
+# https://github.com/MikeSchulze/gdUnit3/blob/master/LICENSE
+
 extends RichTextEffect
 class_name RichTextEffectBackground
 
@@ -8,59 +11,98 @@ var bbcode = "bg"
 
 var _label: WeakRef
 var _char_size :Vector2
-var _char_width : = 8
-var _char_height : = 16
+var _char_width := 8
+var _char_height := 16
+var _tab_size : int
+var _indent := Dictionary()
 var diff_sub_color := Color(0, 0, 0, 0)
 var _cache := Dictionary() 
 
 func _init(label :RichTextLabel):
 	_label = weakref(label)
+	# determine character size
 	var custom_font = label.get("custom_fonts/normal_font")
 	if custom_font is Font:
 		_char_height = custom_font.get_height()
 		_char_width = custom_font.get_char_size(23).x
 	_char_size = Vector2(_char_width, _char_height)
-	var line_separation = label.get("custom_constants/line_separation")
-	if line_separation:
-		_char_height += line_separation
-	else:
-		# default line separation
-		_char_height +=1
+	_tab_size = label.tab_size
+
+func push_indent(line :int, indent :int) -> void:
+	_indent[line] = indent
+
+func pop_indent(line :int, indent :int) -> void:
+	_indent[line+1] = -indent
+	_cache.clear()
 
 func reset() -> void:
 	_cache.clear()
+	_indent.clear()
+
+func get_text_rect(control :Control) -> Rect2:
+	var style : StyleBox = control.get_stylebox("normal")
+	return Rect2(style.get_offset(), control.get_size() - style.get_minimum_size())
 
 func _process_custom_fx(char_fx: CharFXTransform) -> bool:
 	var label = _label.get_ref() as RichTextLabel
 	var scroll = label.get_v_scroll()
-	var position := get_char_position(char_fx.absolute_index, label.text)
+	var position := get_char_position(char_fx.absolute_index, label.get_text())
+	
 	# padding
 	position += Vector2(4, 4)
 	# sync with scroll positon
 	position.y -= scroll.value
 	var color = char_fx.env.get("color", diff_sub_color) as Color
-	# set alpha to lower value for better backround
+	# lower the alpha for better backround
 	color.a = .3
-	label.draw_rect(Rect2(position, _char_size), color);
+	label.draw_rect(Rect2(position, _char_size), color)
+	
+	# increase the color lightning of the character (for better visualisation on background)
 	char_fx.color = char_fx.color.lightened(.8)
 	return true
 
-func get_char_position(char_index :int, text :String ) -> Vector2:
-	var position = _cache.get(char_index)
-	if position is Vector2:
-		return position as Vector2
-	
-	var x_offset := char_index
+func _build_char_mapping(text :String) -> Dictionary:
+	_cache.clear()
+	var line_height := get_line_height()
+	var line_index := 0
+	var char_offset := 0
 	var y_offset := 0
-	for l in text.split("\n"):
-		if x_offset < l.length():
-			break
-		y_offset += 1
-		x_offset -= l.length()
+	var last_ident := 0
 	
-	position = Vector2(x_offset*_char_width, y_offset*_char_height)
-	_cache[char_index] = position
-	return position
+	# replace all tabs, otherwise it will results in invalid background coloring
+	for line in text.replace("\t", "").split("\n"):
+		line_index += 1
+		# build line x_offset by current line indent
+		last_ident = get_line_indent(line_index, last_ident)
+		var x_offset = last_ident * _tab_size
+		
+		for x in line.length():
+			var char_index = char_offset + x
+			_cache[char_index] = Vector2((x_offset + x)*_char_size.x, y_offset)
+		# calculate next line offsets
+		y_offset += line_height
+		char_offset += line.length()
+	return _cache
+
+func get_char_position(char_index :int, text :String ) -> Vector2:
+	if _cache.empty():
+		_build_char_mapping(text)
+	return _cache.get(char_index, Vector2.ONE)
+
+func get_line_indent(line :int, last_indent := 0) -> int:
+	var line_indent = _indent.get(line, 0)
+	if line_indent == 0:
+		return last_indent
+	if line_indent < 0:
+		return last_indent + line_indent
+	return line_indent
+
+func get_line_height() -> int:
+	var label = _label.get_ref() as RichTextLabel
+	var line_separation = label.get("custom_constants/line_separation")
+	if not line_separation:
+		line_separation = 1
+	return get_char_size().y + line_separation
 
 func get_char_size() -> Vector2:
 	return _char_size

--- a/addons/gdUnit3/src/ui/parts/RichTextLabelExt.gd
+++ b/addons/gdUnit3/src/ui/parts/RichTextLabelExt.gd
@@ -1,8 +1,14 @@
+# Custom RichTextLabel with custom background colors
+# MIT License
+# Copyright (c) 2020 Mike Schulze
+# https://github.com/MikeSchulze/gdUnit3/blob/master/LICENSE
+
 tool
 extends RichTextLabel
 class_name RichTextLabelExt
 
 var _effect :RichTextEffectBackground
+var _indent :int
 
 func setup_effects() -> void:
 	_effect = RichTextEffectBackground.new(self)
@@ -13,10 +19,26 @@ func set_bbcode(code) -> void:
 	.parse_bbcode(code)
 	updateMinSize()
 
+func append_bbcode(text :String):
+	# replace all tabs, it results in invalid background coloring
+	return .append_bbcode(text.replace("\t", ""))
+
 func clone() -> RichTextLabelExt:
 	var clone = .duplicate()
 	clone.setup_effects()
 	return clone
+
+func push_indent(indent :int) -> void:
+	.push_indent(indent)
+	if _effect:
+		_indent += indent
+		_effect.push_indent(get_line_count(), _indent)
+
+func pop_indent(indent :int) -> void:
+	.pop()
+	if _effect:
+		_indent -= indent
+		_effect.pop_indent(get_line_count(), _indent)
 
 # updates the label minmum size by the longest line content
 # to fit the full test to on line, to avoid line wrapping

--- a/addons/gdUnit3/test/ui/parts/RichTextEffectBackgroundTest.gd
+++ b/addons/gdUnit3/test/ui/parts/RichTextEffectBackgroundTest.gd
@@ -1,0 +1,85 @@
+# GdUnit generated TestSuite
+#warning-ignore-all:unused_argument
+#warning-ignore-all:return_value_discarded
+class_name RichTextEffectBackgroundTest
+extends GdUnitTestSuite
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit3/src/ui/parts/RichTextEffectBackground.gd'
+
+
+func assert_mapping(mapping :Dictionary, message :String, effect :RichTextEffectBackground):
+	var char_width := effect._char_size.x
+	var char_height := effect.get_line_height()
+	
+	var char_pos := 0
+	var y := 0
+	for line in message.split("\n"):
+		for x in line.length():
+			x += effect.get_line_indent(y)
+			var expected_pos := Vector2(x*char_width, y*char_height)
+			assert_vector2(mapping.get(char_pos))\
+				.is_equal(expected_pos)
+			char_pos += 1
+		y += 1
+
+func test_build_char_mapping_singe_line() -> void:
+	var rtl = auto_free(RichTextLabelExt.new())
+	var effect := RichTextEffectBackground.new(rtl)
+	rtl.install_effect(effect)
+	
+	var message := "This is a Message"
+	var mapping := effect._build_char_mapping(message)
+	
+	assert_mapping(mapping, message, effect)
+
+func test_build_char_mapping_multi_line() -> void:
+	var rtl = auto_free(RichTextLabelExt.new())
+	var effect := RichTextEffectBackground.new(rtl)
+	rtl.install_effect(effect)
+	
+	var message := "This is a Message\nAnd an another Message\nEOF"
+	var mapping := effect._build_char_mapping(message)
+	
+	assert_mapping(mapping, message, effect)
+
+func test_get_line_indent() -> void:
+	var rtl = auto_free(RichTextLabelExt.new())
+	var effect := RichTextEffectBackground.new(rtl)
+	rtl._effect = effect
+	
+	assert_int(effect.get_line_indent(1)).is_equal(0)
+	assert_int(effect.get_line_indent(2)).is_equal(0)
+	
+	# indent = 0
+	rtl.append_bbcode("This is line 1")
+	rtl.newline()
+
+	# indent = 2
+	rtl.push_indent(2)
+	rtl.append_bbcode("This is line 2")
+	rtl.newline()
+	rtl.pop_indent(2)
+	
+	# indent = 0
+	rtl.append_bbcode("This is line 3")
+	rtl.newline()
+	
+	# indent = 2
+	rtl.push_indent(2)
+	rtl.append_bbcode("This is line 4")
+	rtl.newline()
+	
+	# indent = 4
+	rtl.push_indent(2)
+	rtl.append_bbcode("This is line 5")
+	rtl.newline()
+	rtl.pop_indent(2)
+	rtl.pop_indent(2)
+	# indent = 0
+	
+	assert_int(effect.get_line_indent(1)).is_equal(0)
+	assert_int(effect.get_line_indent(2)).is_equal(2)
+	assert_int(effect.get_line_indent(3)).is_equal(0)
+	assert_int(effect.get_line_indent(4)).is_equal(2)
+	assert_int(effect.get_line_indent(5)).is_equal(4)

--- a/project.godot
+++ b/project.godot
@@ -984,6 +984,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gdUnit3/src/ui/parts/RichTextEffectBackground.gd"
 }, {
+"base": "GdUnitTestSuite",
+"class": "RichTextEffectBackgroundTest",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/test/ui/parts/RichTextEffectBackgroundTest.gd"
+}, {
 "base": "RichTextLabel",
 "class": "RichTextLabelExt",
 "language": "GDScript",
@@ -1265,6 +1270,7 @@ _global_script_class_icons={
 "Result": "",
 "ResultTest": "",
 "RichTextEffectBackground": "",
+"RichTextEffectBackgroundTest": "",
 "RichTextLabelExt": "",
 "ScriptWithClassName": "",
 "SignalHandler": "",


### PR DESCRIPTION
- the GdUnit console used indent report lines where was not correct shown (diff colors was incorect placed)  
- speedup rendering by using a precalculated character position cache 