### PR TITLE
GD-202: Add update popup dialoge to plugin by using `add_control_to_container` to have the editor theme

### DIFF
--- a/addons/gdUnit3/plugin.gd
+++ b/addons/gdUnit3/plugin.gd
@@ -42,7 +42,7 @@ func _exit_tree():
 	_gd_console.free()
 	_server_node.free()
 	# Delete and release the update tool only when it is not in use, otherwise it will interrupt the execution of the update
-	if _update_tool and not _update_tool.is_update_in_progress():
+	if is_instance_valid(_update_tool) and not _update_tool.is_update_in_progress():
 		remove_control_from_container(EditorPlugin.CONTAINER_TOOLBAR, _update_tool)
 		_update_tool.free()
 	GdUnitSingleton.remove_singleton(SignalHandler.SINGLETON_NAME)

--- a/addons/gdUnit3/plugin.gd
+++ b/addons/gdUnit3/plugin.gd
@@ -13,7 +13,7 @@ func _enter_tree():
 	# show possible update notification when is enabled
 	if GdUnitSettings.is_update_notification_enabled():
 		_update_tool = load("res://addons/gdUnit3/src/update/GdUnitUpdate.tscn").instance()
-		get_parent().add_child(_update_tool)
+		add_control_to_container(EditorPlugin.CONTAINER_TOOLBAR, _update_tool)
 	
 	# install SignalHandler singleton
 	GdUnitSingleton.add_singleton(SignalHandler.SINGLETON_NAME, "res://addons/gdUnit3/src/core/event/SignalHandler.gd")
@@ -43,8 +43,7 @@ func _exit_tree():
 	_server_node.free()
 	# Delete and release the update tool only when it is not in use, otherwise it will interrupt the execution of the update
 	if _update_tool and not _update_tool.is_update_in_progress():
-		get_parent().call_deferred("remove_child", _update_tool)
-		yield(get_tree(), "idle_frame")
+		remove_control_from_container(EditorPlugin.CONTAINER_TOOLBAR, _update_tool)
 		_update_tool.free()
 	GdUnitSingleton.remove_singleton(SignalHandler.SINGLETON_NAME)
 	Engine.remove_meta("GdUnitEditorPlugin")

--- a/addons/gdUnit3/src/update/GdUnitUpdate.gd
+++ b/addons/gdUnit3/src/update/GdUnitUpdate.gd
@@ -188,10 +188,10 @@ func _on_update_pressed():
 	
 	update_progress("enable GdUnit3 ..")
 	yield(get_tree().create_timer(.5), "timeout")
-	enable_gdUnit()
 	update_progress("New GdUnit successfully installed")
 	yield(get_tree().create_timer(1), "timeout")
 	hide()
+	enable_gdUnit()
 	queue_free()
 
 static func enable_gdUnit() -> void:

--- a/addons/gdUnit3/src/update/GdUnitUpdate.gd
+++ b/addons/gdUnit3/src/update/GdUnitUpdate.gd
@@ -144,7 +144,7 @@ func _on_update_pressed():
 		return
 	update_progress("disable GdUnit3 ..")
 	
-	# remove update content to prevent resource loding issues during update (deleted resources)
+	# remove update content to prevent resource loading issues during update (deleted resources)
 	_content.text = ""
 	_content.bbcode_text = _colored("### Updating ...", Color.snow)
 	# close gdUnit scripts before update

--- a/addons/gdUnit3/src/update/GdUnitUpdate.gd
+++ b/addons/gdUnit3/src/update/GdUnitUpdate.gd
@@ -144,6 +144,9 @@ func _on_update_pressed():
 		return
 	update_progress("disable GdUnit3 ..")
 	
+	# remove update content to prevent resource loding issues during update (deleted resources)
+	_content.text = ""
+	_content.bbcode_text = _colored("### Updating ...", Color.snow)
 	# close gdUnit scripts before update
 	close_open_editor_scripts()
 	disable_gdUnit()


### PR DESCRIPTION

- adding the dialoge to the root node results in showing the ui elements by project theme
  but we want to have the current editor theme
- hide first the update dialoge after succes update before reenable the plugin to prevent resource loading clashes
- Replace the update information before deleting the old resources to avoid errors caused by missing resources.