### PR TITLE
GD-215: Fix failure highlighting on GdUnit Console

### DIFF
--- a/addons/gdUnit3/src/ui/Fonts.gd
+++ b/addons/gdUnit3/src/ui/Fonts.gd
@@ -8,6 +8,8 @@ const FONT_MONO_ITALIC      = "res://addons/gdUnit3/src/update/assets/fonts/stat
 
 
 static func init_fonts(item: CanvasItem) -> float:
+	# add a defauld fallback font
+	item.set("custom_fonts/font", create_font(FONT_MONO, 16))
 	if Engine.editor_hint:
 		var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
 		var settings := plugin.get_editor_interface().get_editor_settings()

--- a/addons/gdUnit3/src/ui/Fonts.gd
+++ b/addons/gdUnit3/src/ui/Fonts.gd
@@ -7,11 +7,11 @@ const FONT_MONO_BOLT_ITALIC = "res://addons/gdUnit3/src/update/assets/fonts/stat
 const FONT_MONO_ITALIC      = "res://addons/gdUnit3/src/update/assets/fonts/static/RobotoMono-Italic.ttf"
 
 
-static func init_fonts(item: CanvasItem) -> int:
+static func init_fonts(item: CanvasItem) -> float:
 	if Engine.editor_hint:
 		var plugin :EditorPlugin = Engine.get_meta("GdUnitEditorPlugin")
 		var settings := plugin.get_editor_interface().get_editor_settings()
-		var scale_factor =  plugin.get_editor_interface().get_editor_scale()
+		var scale_factor :=  plugin.get_editor_interface().get_editor_scale()
 		var font_size = settings.get_setting("interface/editor/main_font_size")
 		font_size *= scale_factor
 		var font_mono := create_font(FONT_MONO, font_size)
@@ -22,9 +22,9 @@ static func init_fonts(item: CanvasItem) -> int:
 		item.set("custom_fonts/bold_italics_font", create_font(FONT_MONO_BOLT_ITALIC, font_size))
 		item.set("custom_fonts/italics_font", create_font(FONT_MONO_ITALIC, font_size))
 		return font_size
-	return 16
+	return 16.0
 
-static func create_font(font_resource: String, size: int) -> Font:
+static func create_font(font_resource: String, size: float) -> Font:
 	var font = DynamicFont.new()
 	font.font_data = load(font_resource)
 	font.size = size

--- a/addons/gdUnit3/src/ui/GdUnitConsole.tscn
+++ b/addons/gdUnit3/src/ui/GdUnitConsole.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://addons/gdUnit3/src/ui/GdUnitConsole.gd" type="Script" id=1]
 [ext_resource path="res://addons/gdUnit3/src/update/assets/fonts/static/RobotoMono-Bold.ttf" type="DynamicFontData" id=2]
@@ -6,32 +6,22 @@
 [ext_resource path="res://addons/gdUnit3/src/update/assets/fonts/static/RobotoMono-Regular.ttf" type="DynamicFontData" id=4]
 [ext_resource path="res://addons/gdUnit3/src/update/assets/fonts/static/RobotoMono-Italic.ttf" type="DynamicFontData" id=5]
 [ext_resource path="res://addons/gdUnit3/src/ui/parts/RichTextLabelExt.gd" type="Script" id=6]
-[ext_resource path="res://addons/gdUnit3/src/ui/parts/RichTextEffectBackground.gd" type="Script" id=7]
 
 [sub_resource type="DynamicFont" id=1]
-size = 18
+size = 14
 font_data = ExtResource( 4 )
 
 [sub_resource type="DynamicFont" id=2]
-size = 18
+size = 14
 font_data = ExtResource( 3 )
 
 [sub_resource type="DynamicFont" id=3]
-size = 18
+size = 14
 font_data = ExtResource( 5 )
 
 [sub_resource type="DynamicFont" id=4]
-size = 18
+size = 14
 font_data = ExtResource( 2 )
-
-[sub_resource type="RichTextEffect" id=5]
-script = ExtResource( 7 )
-
-[sub_resource type="RichTextEffect" id=6]
-script = ExtResource( 7 )
-
-[sub_resource type="RichTextEffect" id=7]
-script = ExtResource( 7 )
 
 [node name="Control" type="Control"]
 use_parent_material = true
@@ -39,6 +29,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 0, 100 )
 rect_clip_content = true
+size_flags_horizontal = 3
+size_flags_vertical = 3
 script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -78,18 +70,21 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Console" type="Panel" parent="VBoxContainer"]
-use_parent_material = true
+[node name="Console" type="ScrollContainer" parent="VBoxContainer"]
 margin_top = 33.0
 margin_right = 1024.0
 margin_bottom = 600.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="TextEdit" type="RichTextLabel" parent="VBoxContainer/Console"]
 use_parent_material = true
-anchor_right = 1.0
-anchor_bottom = 1.0
+margin_right = 1024.0
+margin_bottom = 567.0
+rect_min_size = Vector2( 80, 19 )
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_fonts/mono_font = SubResource( 1 )
@@ -99,7 +94,6 @@ custom_fonts/bold_font = SubResource( 4 )
 custom_fonts/normal_font = SubResource( 1 )
 bbcode_enabled = true
 scroll_following = true
-custom_effects = [ SubResource( 5 ), SubResource( 6 ), SubResource( 7 ) ]
 script = ExtResource( 6 )
 __meta__ = {
 "_edit_use_anchors_": false

--- a/addons/gdUnit3/src/ui/parts/RichTextEffectBackground.gd
+++ b/addons/gdUnit3/src/ui/parts/RichTextEffectBackground.gd
@@ -11,8 +11,6 @@ var bbcode = "bg"
 
 var _label: WeakRef
 var _char_size :Vector2
-var _char_width := 8
-var _char_height := 16
 var _tab_size : int
 var _indent := Dictionary()
 var diff_sub_color := Color(0, 0, 0, 0)
@@ -25,11 +23,13 @@ func set_source(label :RichTextLabel) -> void:
 func init_properties() :
 	_cache.clear()
 	# determine character size
+	var char_width := 8
+	var char_height := 16
 	var custom_font = _label.get_ref().get("custom_fonts/mono_font")
 	if custom_font is Font:
-		_char_height = custom_font.get_height()
-		_char_width = custom_font.get_char_size(23).x
-	_char_size = Vector2(_char_width, _char_height)
+		char_height = custom_font.get_height()
+		char_width = custom_font.get_char_size(23).x
+	_char_size = Vector2(char_width, char_height)
 	_tab_size = _label.get_ref().tab_size
 
 func push_indent(line :int, indent :int) -> void:

--- a/addons/gdUnit3/src/ui/parts/RichTextLabelExt.gd
+++ b/addons/gdUnit3/src/ui/parts/RichTextLabelExt.gd
@@ -45,7 +45,6 @@ func push_indent(indent :int) -> void:
 		_effect.push_indent(get_line_count(), _indent)
 	if _indent > _max_indent:
 		_max_indent = _indent
-		prints("_max_indent", _max_indent)
 
 func pop_indent(indent :int) -> void:
 	.pop()

--- a/addons/gdUnit3/src/ui/parts/RichTextLabelExt.gd
+++ b/addons/gdUnit3/src/ui/parts/RichTextLabelExt.gd
@@ -10,8 +10,9 @@ class_name RichTextLabelExt
 var _effect :RichTextEffectBackground = RichTextEffectBackground.new()
 var _indent :int
 
+
 func _ready():
-	Fonts.init_fonts(self)
+	_update_ui_settings()
 	_effect.set_source(self)
 	# clear effects otherwies a duplicate will result in errors
 	set_effects([])
@@ -19,9 +20,13 @@ func _ready():
 
 func _notification(what):
 	if what == EditorSettings.NOTIFICATION_EDITOR_SETTINGS_CHANGED:
-		Fonts.init_fonts(self)
+		_update_ui_settings()
 		if _effect:
 			_effect._notification(what)
+
+func _update_ui_settings():
+	Fonts.init_fonts(self)
+	updateMinSize()
 
 func set_bbcode(code) -> void:
 	.parse_bbcode(code)
@@ -29,7 +34,9 @@ func set_bbcode(code) -> void:
 
 func append_bbcode(text :String):
 	# replace all tabs, it results in invalid background coloring
-	return .append_bbcode(text.replace("\t", ""))
+	var error := .append_bbcode(text.replace("\t", ""))
+	updateMinSize()
+	return error
 
 func push_indent(indent :int) -> void:
 	.push_indent(indent)
@@ -44,13 +51,15 @@ func pop_indent(indent :int) -> void:
 		_effect.pop_indent(get_line_count(), _indent)
 
 # updates the label minmum size by the longest line content
-# to fit the full test to on line, to avoid line wrapping
+# to fit the full text to on line, to avoid line wrapping
 func updateMinSize() -> void:
-	var min_size := Vector2(0, 0)
+	# reset curren min size
+	rect_min_size.x = 0
+	var font := get("custom_fonts/font") as Font
 	var lines := get_text().split("\n")
 	for line in lines:
-		var chars = line.length() + 1
-		if min_size.x < chars:
-			min_size.x = chars
-	min_size.x *= _effect.get_char_size().x
-	set("rect_min_size", min_size)
+		var line_size := font.get_string_size(line)
+		if rect_min_size < line_size:
+			rect_min_size = line_size
+	# add extra space of 80, the calculated 'get_string_size' not fits right the line wrap size
+	rect_min_size.x += 80

--- a/addons/gdUnit3/src/ui/parts/RichTextLabelExt.gd
+++ b/addons/gdUnit3/src/ui/parts/RichTextLabelExt.gd
@@ -9,7 +9,7 @@ class_name RichTextLabelExt
 
 var _effect :RichTextEffectBackground = RichTextEffectBackground.new()
 var _indent :int
-
+var _max_indent : int = 0
 
 func _ready():
 	_update_ui_settings()
@@ -43,6 +43,9 @@ func push_indent(indent :int) -> void:
 	if _effect:
 		_indent += indent
 		_effect.push_indent(get_line_count(), _indent)
+	if _indent > _max_indent:
+		_max_indent = _indent
+		prints("_max_indent", _max_indent)
 
 func pop_indent(indent :int) -> void:
 	.pop()
@@ -57,9 +60,13 @@ func updateMinSize() -> void:
 	rect_min_size.x = 0
 	var font := get("custom_fonts/font") as Font
 	var lines := get_text().split("\n")
+	# calculate additional indent characters
+	var indent_chars = _max_indent * get_tab_size()
+	var extra_chars = ("%+" + str(indent_chars) + "s") % " "
+	
 	for line in lines:
-		var line_size := font.get_string_size(line)
+		var line_size := font.get_string_size(line + extra_chars)
 		if rect_min_size < line_size:
 			rect_min_size = line_size
-	# add extra space of 80, the calculated 'get_string_size' not fits right the line wrap size
-	rect_min_size.x += 80
+	# add extra spacing of 40px for possible scrollbar
+	rect_min_size.x += 40

--- a/addons/gdUnit3/test/ui/parts/RichTextEffectBackgroundTest.gd
+++ b/addons/gdUnit3/test/ui/parts/RichTextEffectBackgroundTest.gd
@@ -25,9 +25,8 @@ func assert_mapping(mapping :Dictionary, message :String, effect :RichTextEffect
 
 func test_build_char_mapping_singe_line() -> void:
 	var rtl = auto_free(RichTextLabelExt.new())
-	var effect := RichTextEffectBackground.new()
-	effect.set_source(rtl)
-	rtl.install_effect(effect)
+	rtl._ready()
+	var effect :RichTextEffectBackground  = rtl._effect
 	
 	var message := "This is a Message"
 	var mapping := effect._build_char_mapping(message)
@@ -36,9 +35,8 @@ func test_build_char_mapping_singe_line() -> void:
 
 func test_build_char_mapping_multi_line() -> void:
 	var rtl = auto_free(RichTextLabelExt.new())
-	var effect := RichTextEffectBackground.new()
-	effect.set_source(rtl)
-	rtl.install_effect(effect)
+	rtl._ready()
+	var effect :RichTextEffectBackground  = rtl._effect
 	
 	var message := "This is a Message\nAnd an another Message\nEOF"
 	var mapping := effect._build_char_mapping(message)
@@ -47,9 +45,8 @@ func test_build_char_mapping_multi_line() -> void:
 
 func test_get_line_indent() -> void:
 	var rtl = auto_free(RichTextLabelExt.new())
-	var effect := RichTextEffectBackground.new()
-	effect.set_source(rtl)
-	rtl._effect = effect
+	rtl._ready()
+	var effect :RichTextEffectBackground  = rtl._effect
 	
 	assert_int(effect.get_line_indent(1)).is_equal(0)
 	assert_int(effect.get_line_indent(2)).is_equal(0)


### PR DESCRIPTION
- The failure highlighting was placed incorrectly when the text is warped.
  Now the minimum text field length is set to the maximum text length to avoid line breaks.