### PR TITLE
GD-214: Fix GdUnit configurations dialog to show all properties

### DIFF
--- a/addons/gdUnit3/src/ui/GdUnitToolsDialog.gd
+++ b/addons/gdUnit3/src/ui/GdUnitToolsDialog.gd
@@ -11,7 +11,7 @@ onready var _progress :ProgressBar = $v/MarginContainer2/HBoxContainer/ProgressB
 onready var _progress_text :Label = $v/MarginContainer2/HBoxContainer/ProgressBar/Label
 
 onready var _properties_template :Node = $property_template
-onready var _properties_common :Node = $v/MarginContainer/GridContainer/Properties/Common/VBoxContainer
+onready var _properties_common :Node = $v/MarginContainer/GridContainer/Properties/Common/ScrollContainer/VBoxContainer
 onready var _properties_report :Node = $v/MarginContainer/GridContainer/Properties/Report/VBoxContainer
 
 var _font_size :int
@@ -33,9 +33,10 @@ func setup_common_properties(properties_parent :Node, property_category) -> void
 	category_properties.sort_custom(self, "_sort_by_key")
 	var t := Theme.new()
 	t.set_constant("hseparation", "GridContainer", 12)
-	
 	var last_category := "!"
+	var min_size_overall := 0
 	for p in category_properties:
+		var min_size := 0
 		var grid := GridContainer.new()
 		grid.columns = 4
 		grid.theme = t
@@ -51,47 +52,55 @@ func setup_common_properties(properties_parent :Node, property_category) -> void
 		# property name
 		var label :Label = _properties_template.get_child(0).duplicate()
 		label.text = _to_human_readable(property.name())
-		label.set_custom_minimum_size(Vector2(300, 0))
+		label.set_custom_minimum_size(Vector2(_font_size * 20, 0))
 		grid.add_child(label)
+		min_size += label.rect_size.x
 		
 		# property reset btn
 		var reset_btn :ToolButton = _properties_template.get_child(1).duplicate()
 		reset_btn.icon = _get_btn_icon("Reload")
 		reset_btn.disabled = property.value() == property.default()
 		grid.add_child(reset_btn)
+		min_size += reset_btn.rect_size.x
 		
 		# property type specific input element
 		var input :Node = _create_input_element(property, reset_btn)
+		input.set_custom_minimum_size(Vector2(_font_size * 15, 0))
 		grid.add_child(input)
+		min_size +=  input.rect_size.x
 		reset_btn.connect("pressed", self, "_on_btn_property_reset_pressed", [property, input, reset_btn])
 		# property help text
 		var info :Node = _properties_template.get_child(2).duplicate()
 		info.text = property.help()
 		grid.add_child(info)
+		min_size += info.text.length() * _font_size
+		if min_size_overall < min_size:
+			min_size_overall = min_size
 		properties_parent.add_child(grid)
+	properties_parent.rect_min_size.x = min_size_overall
 
 func _create_input_element(property: GdUnitProperty, reset_btn :ToolButton) -> Node:
 	if property.is_selectable_value():
 		var options := OptionButton.new()
+		options.align = OptionButton.ALIGN_CENTER
 		var values_set := Array(property.value_set())
 		for value in values_set:
 			options.add_item(value)
 		options.connect("item_selected", self, "_on_option_selected", [property, reset_btn])
 		options.select(property.value())
-		options.set_custom_minimum_size(Vector2(120, 0))
 		return options
 	if property.type() == TYPE_BOOL: 
 		var check_btn := CheckButton.new()
 		check_btn.connect("toggled", self, "_on_property_text_changed", [property, reset_btn])
 		check_btn.pressed = property.value()
-		check_btn.set_custom_minimum_size(Vector2(120, 0))
 		return check_btn
 	if property.type() in [TYPE_INT, TYPE_STRING]:
 			var input := LineEdit.new()
 			input.connect("text_changed", self, "_on_property_text_changed", [property, reset_btn])
+			input.set_context_menu_enabled(false)
+			input.set_align(LineEdit.ALIGN_CENTER)
+			input.set_expand_to_text_length(true)
 			input.text = str(property.value())
-			input.set_align(HALIGN_RIGHT)
-			input.set_custom_minimum_size(Vector2(120, 0))
 			return input 
 	return Control.new()
 

--- a/addons/gdUnit3/src/ui/GdUnitToolsDialog.tscn
+++ b/addons/gdUnit3/src/ui/GdUnitToolsDialog.tscn
@@ -76,8 +76,6 @@ size_flags_horizontal = 3
 anchor_right = 1.0
 anchor_bottom = 1.0
 custom_colors/font_color = Color( 0.196078, 0.631373, 0.639216, 1 )
-text = "Asserts
-"
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
@@ -232,13 +230,17 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 tab_align = 0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="v/MarginContainer/GridContainer/Properties/Common"]
+[node name="ScrollContainer" type="ScrollContainer" parent="v/MarginContainer/GridContainer/Properties/Common"]
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 8.0
-margin_top = 8.0
-margin_right = -8.0
-margin_bottom = -8.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="VBoxContainer" type="VBoxContainer" parent="v/MarginContainer/GridContainer/Properties/Common/ScrollContainer"]
+margin_right = 1347.0
+margin_bottom = 372.0
+rect_min_size = Vector2( 1347, 0 )
 rect_clip_content = true
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -263,6 +265,7 @@ margin_left = 8.0
 margin_top = 8.0
 margin_right = -8.0
 margin_bottom = -8.0
+rect_min_size = Vector2( 773, 0 )
 rect_clip_content = true
 size_flags_horizontal = 3
 size_flags_vertical = 3


### PR DESCRIPTION
- the property values was not fully displayed if using alignment RIGHT, swichted to CENTER
- added scroll container fit the conten an show scrollbar if need