### PR TITLE
GD-231: Print failure report on comand line tool execution

### DIFF
--- a/.github/workflows/selftest-3.3.x-mono.yml
+++ b/.github/workflows/selftest-3.3.x-mono.yml
@@ -34,7 +34,7 @@ jobs:
           msbuild
 
       - name: Run Selftes
-        timeout-minutes: 7
+        timeout-minutes: 10
         env:
           GODOT_BIN: "/usr/local/bin/godot"
         shell: bash

--- a/.github/workflows/selftest-3.3.x.yml
+++ b/.github/workflows/selftest-3.3.x.yml
@@ -32,7 +32,7 @@ jobs:
         run: echo "GODOT_BIN=/usr/local/bin/godot" >> $GITHUB_ENV
 
       - name: Run Selftes
-        timeout-minutes: 5
+        timeout-minutes: 10
         shell: bash
         run: ./runtest.sh --selftest
 

--- a/.github/workflows/selftest-3.4.x.yml
+++ b/.github/workflows/selftest-3.4.x.yml
@@ -32,7 +32,7 @@ jobs:
         run: echo "GODOT_BIN=/usr/local/bin/godot" >> $GITHUB_ENV
 
       - name: Run Selftes
-        timeout-minutes: 5
+        timeout-minutes: 10
         shell: bash
         run: ./runtest.sh --selftest
 

--- a/addons/gdUnit3/src/report/GdUnitTestCaseReport.gd
+++ b/addons/gdUnit3/src/report/GdUnitTestCaseReport.gd
@@ -2,8 +2,9 @@ class_name GdUnitTestCaseReport
 extends GdUnitReportSummary
 
 var _failure_reports :Array
+var _rtf :RichTextLabel
 
-func _init(resource_path :String, test_name :String, is_error :bool = false, is_failed :bool = false, orphans :int = 0, skipped :int = 0, failure_reports :Array = [], duration :int = 0):
+func _init(rtf :RichTextLabel, resource_path :String, test_name :String, is_error :bool = false, is_failed :bool = false, orphans :int = 0, skipped :int = 0, failure_reports :Array = [], duration :int = 0):
 	_resource_path = resource_path
 	_name = test_name
 	_test_count = 1
@@ -13,6 +14,7 @@ func _init(resource_path :String, test_name :String, is_error :bool = false, is_
 	_skipped_count = skipped
 	_failure_reports = failure_reports
 	_duration = duration
+	_rtf = rtf
 
 func failure_report() -> String:
 	var html_report := ""
@@ -23,10 +25,9 @@ func failure_report() -> String:
 	return html_report
 
 func convert_rtf_to_text(bbcode :String) -> String:
-	var rtf := RichTextLabel.new()
-	rtf.parse_bbcode(bbcode)
-	var as_text: = rtf.text
-	rtf.free()
+	_rtf.clear()
+	_rtf.parse_bbcode(bbcode)
+	var as_text: = _rtf.text
 	var converted := PoolStringArray()
 	var lines := as_text.split("\n")
 	for line in lines:


### PR DESCRIPTION
- failure reports now printed out for failing tests
- reduce font loading by using a single instance of RTL