### PR TITLE
GD-248: Mock was failing for a class that directly calls an inheritance method

### DIFF
--- a/addons/gdUnit3/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit3/src/core/parse/GdScriptParser.gd
@@ -345,21 +345,21 @@ func parse_arguments(row: String) -> Array:
 	var current_index := 0
 	var token :Token = null
 	var bracket := 0
-	var next_tokens : = [TOKEN_FUNCTION_DECLARATION]
+	var in_function := false
 	while current_index < len(input):
 		token = next_token(input, current_index)
 		current_index += token._consumed
 		if token == TOKEN_BRACKET_OPEN:
+			in_function = true
 			bracket += 1
-		if token == TOKEN_BRACKET_CLOSE:
-			bracket -= 1
-		if not next_tokens.has(token) and not token.is_variable() :
 			continue
+		# if function has no args or all args has parsed?
+		if token == TOKEN_BRACKET_CLOSE or (in_function and bracket == 0):
+			return args
 		# is function
 		if token == TOKEN_FUNCTION_DECLARATION:
 			token = next_token(input, current_index)
 			current_index += token._consumed
-			next_tokens = [TOKEN_BRACKET_OPEN, TOKEN_BRACKET_CLOSE]
 			continue
 		# is argument
 		if bracket == 1 and token.is_variable():

--- a/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
@@ -112,6 +112,11 @@ func test_parse_arguments():
 		.contains_exactly([
 			GdFunctionArgument.new("timeout", "float")])
 
+func test_parse_arguments_with_super_constructor():
+	assert_array(_parser.parse_arguments('func foo().foo("abc"):')).is_empty()
+	assert_array(_parser.parse_arguments('func foo(arg1 = "arg").foo("abc", arg1):'))\
+		.contains_exactly([GdFunctionArgument.new("arg1", "", '"arg"')])
+
 func test_parse_arguments_default_build_in_type_String():
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2=\"default\"):")) \
 		.contains_exactly([

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -907,3 +907,15 @@ func test_mock_scene_execute_func_yielded() -> void:
 	verify(mocked_scene).emit_signal("panel_color_change", mocked_scene._box1, Color.red)
 	verify(mocked_scene).emit_signal("panel_color_change", mocked_scene._box1, Color.blue)
 	verify(mocked_scene).emit_signal("panel_color_change", mocked_scene._box1, Color.green)
+
+class Base:
+	func _init(value :String):
+		pass
+
+class Foo extends Base:
+	func _init().("test"):
+		pass
+
+func test_mock_with_inheritance_method() -> void:
+	var foo := mock(Foo) as Foo
+	assert_object(foo).is_not_null()


### PR DESCRIPTION

- The parser did not stop parsing at the function head end.
  Fixed by stopping parsing when the function head end is reached.