### PR TITLE
GD-256: Build a mock inherits with the wrong class if the filename matches an existing class

### DIFF
--- a/.github/workflows/selftest-3.3.x-mono.yml
+++ b/.github/workflows/selftest-3.3.x-mono.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Compile
         run: |
-          nuget restore
+          dotnet restore gdUnit3.csproj
           mkdir -p .mono/assemblies/Debug
           cp /usr/local/bin/GodotSharp/Api/Release/* .mono/assemblies/Debug
           dotnet build -verbosity:m

--- a/addons/gdUnit3/src/core/GdObjects.gd
+++ b/addons/gdUnit3/src/core/GdObjects.gd
@@ -482,6 +482,8 @@ static func extract_class_name(clazz) -> Result:
 
 	# extract name form full qualified class path
 	if clazz is String:
+		if ClassDB.class_exists(clazz):
+			return Result.success(clazz)
 		var source_sript :Script = load(clazz)
 		var clazz_name = load("res://addons/gdUnit3/src/core/parse/GdScriptParser.gd").new().get_class_name(source_sript)
 		return Result.success(to_pascal_case(clazz_name))
@@ -490,8 +492,10 @@ static func extract_class_name(clazz) -> Result:
 		return Result.error("Can't extract class name for an primitive '%s'" % type_as_string(typeof(clazz)))
 
 	if is_script(clazz):
-		var clazz_path := extract_class_path(clazz)
-		return Result.success(extract_class_name_from_class_path(clazz_path))
+		if clazz.resource_path.empty():
+			var class_path = extract_class_name_from_class_path(extract_class_path(clazz))
+			return Result.success(class_path);
+		return extract_class_name(clazz.resource_path)
 
 	# need to create an instance for a class typ the extract the class name
 	var instance = clazz.new()

--- a/addons/gdUnit3/src/core/GdObjects.gd
+++ b/addons/gdUnit3/src/core/GdObjects.gd
@@ -476,8 +476,7 @@ static func extract_class_name(clazz) -> Result:
 		# is instance a script instance?
 		var script := clazz.script as GDScript
 		if script != null:
-			var clazz_path := extract_class_path(script)
-			return Result.success(extract_class_name_from_class_path(clazz_path))
+			return extract_class_name(script)
 		return Result.success(clazz.get_class())
 
 	# extract name form full qualified class path

--- a/addons/gdUnit3/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit3/src/core/parse/GdScriptParser.gd
@@ -528,7 +528,7 @@ func get_class_name(script :GDScript) -> String:
 		var input = clean_up_row(source_rows[index])
 		var token := next_token(input, 0)
 		if token == TOKEN_CLASS_NAME:
-			token = next_token(input, token._consumed)
+			token = tokenize_value(input, token._consumed, token)
 			return token.value()
 	# if no class_name found extract from file name
 	return GdObjects.to_pascal_case(script.resource_path.get_basename().get_file())

--- a/addons/gdUnit3/src/mocking/GdUnitMockBuilder.gd
+++ b/addons/gdUnit3/src/mocking/GdUnitMockBuilder.gd
@@ -169,10 +169,11 @@ static func build(caller :Object, clazz, mock_mode :String, debug_write = false)
 	elif typeof(clazz) == TYPE_STRING and clazz.ends_with(".tscn"):
 		return mock_on_scene(caller, load(clazz), memory_pool, debug_write)
 	# mocking a script
-	var mock = mock_on_script(clazz, [], debug_write)
+	var mock = mock_on_script(clazz, ["set_script", "get_script"], debug_write)
 	if mock == null:
 		return null
 	var mock_instance = mock.new()
+	mock_instance.set_script(mock)
 	mock_instance.__set_singleton()
 	mock_instance.__set_mode(mock_mode)
 	mock_instance.__set_caller(caller)

--- a/addons/gdUnit3/src/mocking/GdUnitMockBuilder.gd
+++ b/addons/gdUnit3/src/mocking/GdUnitMockBuilder.gd
@@ -163,13 +163,13 @@ static func build(caller :Object, clazz, mock_mode :String, debug_write = false)
 	var push_errors := is_push_error_enabled()
 	if not is_mockable(clazz, push_errors):
 		return null
-	
+	# mocking a scene?
 	if GdObjects.is_scene(clazz):
 		return mock_on_scene(caller, clazz as PackedScene, memory_pool, debug_write)
 	elif typeof(clazz) == TYPE_STRING and clazz.ends_with(".tscn"):
 		return mock_on_scene(caller, load(clazz), memory_pool, debug_write)
-	
-	var mock = mock_on_script(clazz, mock_mode, memory_pool, [], debug_write)
+	# mocking a script
+	var mock = mock_on_script(clazz, [], debug_write)
 	if mock == null:
 		return null
 	var mock_instance = mock.new()
@@ -193,7 +193,7 @@ static func mock_on_scene(caller :Object, scene :PackedScene, memory_pool :int, 
 		return null
 	
 	var script_path = scene_instance.get_script().get_path()
-	var mock = mock_on_script(script_path, GdUnitMock.CALL_REAL_FUNC, memory_pool, GdUnitClassDoubler.EXLCUDE_SCENE_FUNCTIONS, debug_write)
+	var mock = mock_on_script(script_path, GdUnitClassDoubler.EXLCUDE_SCENE_FUNCTIONS, debug_write)
 	if mock == null:
 		return null
 	scene_instance.set_script(mock)
@@ -202,13 +202,9 @@ static func mock_on_scene(caller :Object, scene :PackedScene, memory_pool :int, 
 	scene_instance.__set_caller(caller)
 	return GdUnitTools.register_auto_free(scene_instance, memory_pool)
 
-static func mock_on_script(clazz, mock_mode :String, memory_pool :int, function_excludes :PoolStringArray, debug_write :bool) -> GDScript:
-	var clazz_name :String
+static func mock_on_script(clazz, function_excludes :PoolStringArray, debug_write :bool) -> GDScript:
 	var clazz_path := GdObjects.extract_class_path(clazz)
-	if clazz_path.empty():
-		clazz_name = GdObjects.extract_class_name(clazz).value()
-	else:
-		clazz_name = GdObjects.extract_class_name_from_class_path(clazz_path)
+	var	clazz_name = GdObjects.extract_class_name(clazz).value()
 	
 	var push_errors := is_push_error_enabled()
 	var function_doubler := MockFunctionDoubler.new(push_errors)

--- a/addons/gdUnit3/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit3/src/spy/GdUnitSpyBuilder.gd
@@ -139,7 +139,7 @@ static func build(caller :Object, to_spy, push_errors :bool = true, debug_write 
 	if GdObjects.is_instance_scene(to_spy):
 		return spy_on_scene(caller, to_spy, memory_pool, debug_write)
 	
-	var spy := spy_on_script(to_spy, memory_pool, [], debug_write)
+	var spy := spy_on_script(to_spy, [], debug_write)
 	if spy == null:
 		return null
 	var spy_instance = spy.new()
@@ -147,7 +147,7 @@ static func build(caller :Object, to_spy, push_errors :bool = true, debug_write 
 	spy_instance.__set_caller(caller)
 	return GdUnitTools.register_auto_free(spy_instance, memory_pool)
 
-static func spy_on_script(instance, memory_pool, function_excludes :PoolStringArray, debug_write) -> GDScript:
+static func spy_on_script(instance, function_excludes :PoolStringArray, debug_write) -> GDScript:
 	var result := GdObjects.extract_class_name(instance)
 	if result.is_error():
 		push_error("Internal ERROR: %s" % result.error_message())
@@ -190,7 +190,7 @@ static func spy_on_scene(caller :Object, scene :Node, memory_pool, debug_write) 
 		return null
 	# buils spy on original script
 	var scene_script = scene.get_script().new()
-	var spy := spy_on_script(scene_script, memory_pool, GdUnitClassDoubler.EXLCUDE_SCENE_FUNCTIONS, debug_write)
+	var spy := spy_on_script(scene_script, GdUnitClassDoubler.EXLCUDE_SCENE_FUNCTIONS, debug_write)
 	scene_script.free()
 	if spy == null:
 		return null

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -112,6 +112,23 @@ func test_mock_Node():
 	assert_that(mocked_node.get_child_count()).is_equal(24)
 
 
+func test_mock_source_with_class_name_by_resource_path() -> void:
+	var resource_path := 'res://addons/gdUnit3/test/mocker/resources/GD-256/world.gd'
+	var m = mock(resource_path)
+	var head :String = m.get_script().source_code.substr(0, 200)
+	assert_str(head)\
+		.contains("class_name DoubledMunderwoodPathingWorld")\
+		.contains("extends '%s'" % resource_path)
+
+func test_mock_source_with_class_name_by_class() -> void:
+	var resource_path := 'res://addons/gdUnit3/test/mocker/resources/GD-256/world.gd'
+	var m = mock(Munderwood_Pathing_World)
+	var head :String = m.get_script().source_code.substr(0, 200)
+	assert_str(head)\
+		.contains("class_name DoubledMunderwoodPathingWorld")\
+		.contains("extends '%s'" % resource_path)
+
+
 var _test_signal_is_emited := false
 func _emit_ready(a, b, c):
 	prints("_emit_ready", a, b, c)

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -128,6 +128,12 @@ func test_mock_source_with_class_name_by_class() -> void:
 		.contains("class_name DoubledMunderwoodPathingWorld")\
 		.contains("extends '%s'" % resource_path)
 
+func test_mock_extends_godot_class() -> void:
+	var m = mock(World)
+	var head :String = m.get_script().source_code.substr(0, 200)
+	assert_str(head)\
+		.contains("class_name DoubledWorld")\
+		.contains("extends World")
 
 var _test_signal_is_emited := false
 func _emit_ready(a, b, c):

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -111,7 +111,6 @@ func test_mock_Node():
 	# verify the return value is overwritten
 	assert_that(mocked_node.get_child_count()).is_equal(24)
 
-
 func test_mock_source_with_class_name_by_resource_path() -> void:
 	var resource_path := 'res://addons/gdUnit3/test/mocker/resources/GD-256/world.gd'
 	var m = mock(resource_path)

--- a/addons/gdUnit3/test/mocker/GodotClassNameFuzzer.gd
+++ b/addons/gdUnit3/test/mocker/GodotClassNameFuzzer.gd
@@ -3,7 +3,7 @@ class_name GodotClassNameFuzzer
 extends Fuzzer
 
 var class_names := []
-const EXCLUDED_CLASSES = ["JavaClass", "_ClassDB", "MainLoop", "JNISingleton", "SceneTree", "WebRTC"]
+const EXCLUDED_CLASSES = ["JavaClass", "_ClassDB", "MainLoop", "JNISingleton", "SceneTree", "WebRTC", "WebRTCPeerConnection"]
 
 func _init(no_singleton :bool = false, only_instancialbe :bool = false) -> void:
 	#class_names = ClassDB.get_class_list()

--- a/addons/gdUnit3/test/mocker/resources/ClassWithCustomClassName.gd
+++ b/addons/gdUnit3/test/mocker/resources/ClassWithCustomClassName.gd
@@ -1,0 +1,3 @@
+class_name GdUnit_Test_CustomClassName
+extends Resource
+

--- a/addons/gdUnit3/test/mocker/resources/GD-256/world.gd
+++ b/addons/gdUnit3/test/mocker/resources/GD-256/world.gd
@@ -1,0 +1,5 @@
+extends Node
+class_name Munderwood_Pathing_World
+
+func foo() -> String: 
+	return "test"

--- a/addons/gdUnit3/test/mocking/GdUnitMockBuilderTest.gd
+++ b/addons/gdUnit3/test/mocking/GdUnitMockBuilderTest.gd
@@ -213,3 +213,25 @@ func test_double_virtual_script_function_with_arg() -> void:
 		"		return ._input(event_)",
 		"	return null",
 		""])
+
+func test_mock_on_script_path_without_class_name() -> void:
+	var script := GdUnitMockBuilder.mock_on_script("res://addons/gdUnit3/test/mocker/resources/ClassWithoutNameA.gd", [], false);
+	assert_that(script.resource_name).is_equal("MockClassWithoutNameA.gd")
+	assert_that(script.get_instance_base_type()).is_equal("Resource")
+
+func test_mock_on_script_path_with_custom_class_name() -> void:
+	# the class contains a class_name definition
+	var script := GdUnitMockBuilder.mock_on_script("res://addons/gdUnit3/test/mocker/resources/ClassWithCustomClassName.gd", [], false);
+	assert_that(script.resource_name).is_equal("MockGdUnitTestCustomClassName.gd")
+	assert_that(script.get_instance_base_type()).is_equal("Resource")
+
+func test_mock_on_class_with_class_name() -> void:
+	var script := GdUnitMockBuilder.mock_on_script(ClassWithNameA, [], false);
+	assert_that(script.resource_name).is_equal("MockClassWithNameA.gd")
+	assert_that(script.get_instance_base_type()).is_equal("Resource")
+
+func test_mock_on_class_with_custom_class_name() -> void:
+	# the class contains a class_name definition
+	var script := GdUnitMockBuilder.mock_on_script(GdUnit_Test_CustomClassName, [], false);
+	assert_that(script.resource_name).is_equal("MockGdUnitTestCustomClassName.gd")
+	assert_that(script.get_instance_base_type()).is_equal("Resource")

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -40,6 +40,27 @@ func test_spy_on_Node():
 	verify(spy_node, 2).set_process(false)
 	verify(spy_node, 2).set_process(false)
 
+func test_spy_source_with_class_name_by_resource_path() -> void:
+	var instance = auto_free(load('res://addons/gdUnit3/test/mocker/resources/GD-256/world.gd').new())
+	var m = spy(instance)
+	var head :String = m.get_script().source_code.substr(0, 200)
+	assert_str(head)\
+		.contains("class_name DoubledMunderwoodPathingWorld")\
+		.contains("extends 'res://addons/gdUnit3/test/mocker/resources/GD-256/world.gd'")
+
+func test_spy_source_with_class_name_by_class() -> void:
+	var m = spy(auto_free(Munderwood_Pathing_World.new()))
+	var head :String = m.get_script().source_code.substr(0, 200)
+	assert_str(head)\
+		.contains("class_name DoubledMunderwoodPathingWorld")\
+		.contains("extends 'res://addons/gdUnit3/test/mocker/resources/GD-256/world.gd'")
+
+func test_spy_extends_godot_class() -> void:
+	var m = spy(auto_free(World.new()))
+	var head :String = m.get_script().source_code.substr(0, 200)
+	assert_str(head)\
+		.contains("class_name DoubledWorld")\
+		.contains("extends World")
 
 func test_spy_on_custom_class():
 	var instance :AdvancedTestClass = auto_free(AdvancedTestClass.new())

--- a/project.godot
+++ b/project.godot
@@ -1406,7 +1406,6 @@ enabled=PoolStringArray( "res://addons/gdUnit3/plugin.cfg" )
 
 [gdunit3]
 
-report/godot/push_error=true
 report/assert/verbose_errors=false
 report/assert/verbose_warnings=false
 

--- a/project.godot
+++ b/project.godot
@@ -914,6 +914,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gdUnit3/test/asserts/GdUnitVector3AssertImplTest.gd"
 }, {
+"base": "Resource",
+"class": "GdUnit_Test_CustomClassName",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/test/mocker/resources/ClassWithCustomClassName.gd"
+}, {
 "base": "GdUnitTestSuite",
 "class": "GeneratedPersonTest",
 "language": "GDScript",
@@ -1326,6 +1331,7 @@ _global_script_class_icons={
 "GdUnitVector3Assert": "",
 "GdUnitVector3AssertImpl": "",
 "GdUnitVector3AssertImplTest": "",
+"GdUnit_Test_CustomClassName": "",
 "GeneratedPersonTest": "",
 "GodotClassNameFuzzer": "",
 "GodotGdErrorMonitor": "",
@@ -1391,6 +1397,11 @@ gdscript/warnings/return_value_discarded=false
 [editor_plugins]
 
 enabled=PoolStringArray( "res://addons/gdUnit3/plugin.cfg" )
+
+[gdunit3]
+
+report/assert/verbose_errors=false
+report/assert/verbose_warnings=false
 
 [network]
 

--- a/project.godot
+++ b/project.godot
@@ -974,6 +974,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gdUnit3/test/core/LocalTimeTest.gd"
 }, {
+"base": "Node",
+"class": "Munderwood_Pathing_World",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/test/mocker/resources/GD-256/world.gd"
+}, {
 "base": "GdUnitTestSuite",
 "class": "NetworkServerTest",
 "language": "GDScript",
@@ -1343,6 +1348,7 @@ _global_script_class_icons={
 "JUnitXmlReportTest": "",
 "LocalTime": "",
 "LocalTimeTest": "",
+"Munderwood_Pathing_World": "",
 "NetworkServerTest": "",
 "OverridenGetClassTestClass": "",
 "PascalCaseWithClassName": "",
@@ -1400,6 +1406,7 @@ enabled=PoolStringArray( "res://addons/gdUnit3/plugin.cfg" )
 
 [gdunit3]
 
+report/godot/push_error=true
 report/assert/verbose_errors=false
 report/assert/verbose_warnings=false
 


### PR DESCRIPTION
- using now the `class_name` of source class to build the mock class name instead grabing from resource path
  We do this because the `class_name` can be differ from file name.
- if no `class_name` defined we fallback to the grap class name from file
- cleanup unused arguments on mock and spy builder
- replace nuget restore by dotnet restore to solve flaky build errors 