### PR TITLE
GD-262: Fixed parsing of test suites without namespace

### DIFF
--- a/addons/gdUnit3/src/core/GdUnitTestSuiteBuilder.cs
+++ b/addons/gdUnit3/src/core/GdUnitTestSuiteBuilder.cs
@@ -80,9 +80,14 @@ namespace GdUnit3.Core
             try
             {
                 var root = CSharpSyntaxTree.ParseText(File.ReadAllText(classPath)).GetCompilationUnitRoot();
-                NamespaceDeclarationSyntax namespaceSyntax = root.Members.OfType<NamespaceDeclarationSyntax>().First();
-                ClassDeclarationSyntax programClassSyntax = namespaceSyntax.Members.OfType<ClassDeclarationSyntax>().First();
-                return Type.GetType(namespaceSyntax.Name.ToString() + "." + programClassSyntax.Identifier.ValueText);
+                NamespaceDeclarationSyntax namespaceSyntax = root.Members.OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
+                if (namespaceSyntax != null)
+                {
+                    ClassDeclarationSyntax classSyntax = namespaceSyntax.Members.OfType<ClassDeclarationSyntax>().First();
+                    return Type.GetType(namespaceSyntax.Name.ToString() + "." + classSyntax.Identifier.ValueText);
+                }
+                ClassDeclarationSyntax programClassSyntax = root.Members.OfType<ClassDeclarationSyntax>().First();
+                return Type.GetType(programClassSyntax.Identifier.ValueText);
             }
 #pragma warning disable CS0168
             catch (Exception e)

--- a/addons/gdUnit3/test/core/GdUnitTestSuiteBuilderTest.cs
+++ b/addons/gdUnit3/test/core/GdUnitTestSuiteBuilderTest.cs
@@ -20,6 +20,7 @@ namespace GdUnit3.Core.Tests
         [TestCase]
         public void ParseType()
         {
+            AssertObject(GdUnitTestSuiteBuilder.ParseType("addons/gdUnit3/test/core/resources/testsuites/mono/noSpace/TestSuiteWithoutNamespace.cs")).IsEqual(typeof(TestSuiteWithoutNamespace));
             AssertObject(GdUnitTestSuiteBuilder.ParseType("addons/gdUnit3/test/core/resources/testsuites/mono/spaceA/TestSuite.cs")).IsEqual(typeof(GdUnit3.Tests.SpaceA.TestSuite));
             AssertObject(GdUnitTestSuiteBuilder.ParseType("addons/gdUnit3/test/core/resources/testsuites/mono/spaceB/TestSuite.cs")).IsEqual(typeof(GdUnit3.Tests.SpaceB.TestSuite));
             // source file not exists

--- a/addons/gdUnit3/test/core/resources/testsuites/mono/noSpace/TestSuiteWithoutNamespace.cs
+++ b/addons/gdUnit3/test/core/resources/testsuites/mono/noSpace/TestSuiteWithoutNamespace.cs
@@ -1,0 +1,4 @@
+public class TestSuiteWithoutNamespace
+{
+
+}


### PR DESCRIPTION
- The recognition of an test suite was interrupted if no namespace was defined.