### PR TITLE
GD-263: Tests was not found when changing the `test root folder` property

### DIFF
--- a/addons/gdUnit3/src/core/_TestSuiteScanner.gd
+++ b/addons/gdUnit3/src/core/_TestSuiteScanner.gd
@@ -55,9 +55,6 @@ static func _file(dir :Directory, file_name :String) -> String:
 func _parse_is_test_suite(resource_path :String) -> Node:
 	if not _is_script_format_supported(resource_path):
 		return null
-	# exclude non test directories
-	if resource_path.find("/test") == -1:
-		return null
 	var script :Script = ResourceLoader.load(resource_path)
 	if not GdObjects.is_test_suite(script):
 		return null

--- a/addons/gdUnit3/test/core/TestSuiteScannerTest.gd
+++ b/addons/gdUnit3/test/core/TestSuiteScannerTest.gd
@@ -1,0 +1,25 @@
+# GdUnit generated TestSuite
+#warning-ignore-all:unused_argument
+#warning-ignore-all:return_value_discarded
+class_name TestSuiteScannerTest
+extends GdUnitTestSuite
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit3/src/core/_TestSuiteScanner.gd'
+
+
+func resolve_path(source_file :String) -> String:
+	return _TestSuiteScanner.resolve_test_suite_path(source_file, "_test_")
+
+func test_resolve_test_suite_path_project() -> void:
+	# if no `src` folder found use test folder as root
+	assert_str(resolve_path("res://foo.gd")).is_equal("res://_test_/foo_test.gd")
+	assert_str(resolve_path("res://project_name/module/foo.gd")).is_equal("res://_test_/project_name/module/foo_test.gd")
+	# otherwise build relative to 'src'
+	assert_str(resolve_path("res://src/foo.gd")).is_equal("res://_test_/foo_test.gd")
+	assert_str(resolve_path("res://project_name/src/foo.gd")).is_equal("res://project_name/_test_/foo_test.gd")
+	assert_str(resolve_path("res://project_name/src/module/foo.gd")).is_equal("res://project_name/_test_/module/foo_test.gd")
+	
+func test_resolve_test_suite_path_plugins() -> void:
+	assert_str(resolve_path("res://addons/plugin_a/foo.gd")).is_equal("res://addons/plugin_a/_test_/foo_test.gd")
+	assert_str(resolve_path("res://addons/plugin_a/src/foo.gd")).is_equal("res://addons/plugin_a/_test_/foo_test.gd")

--- a/project.godot
+++ b/project.godot
@@ -1095,6 +1095,11 @@ _global_script_classes=[ {
 "path": "res://addons/gdUnit3/test/fuzzers/TestExternalFuzzer.gd"
 }, {
 "base": "GdUnitTestSuite",
+"class": "TestSuiteScannerTest",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/test/core/TestSuiteScannerTest.gd"
+}, {
+"base": "GdUnitTestSuite",
 "class": "TestSuiteTemplateTest",
 "language": "GDScript",
 "path": "res://addons/gdUnit3/test/ui/templates/TestSuiteTemplateTest.gd"
@@ -1372,6 +1377,7 @@ _global_script_class_icons={
 "StringFuzzer": "",
 "StringFuzzerTest": "",
 "TestExternalFuzzer": "",
+"TestSuiteScannerTest": "",
 "TestSuiteTemplateTest": "",
 "TimeUnit": "",
 "Udo": "",


### PR DESCRIPTION

- a small pice of hard coded path check was stopping the test scanning.
  removed it do alow scanning each folder
- added test coverage for test folder generation