### PR TITLE
GD-280: `await_signal_on` do now return the emited value

### DIFF
--- a/addons/gdUnit3/src/GdUnitAwaiter.gd
+++ b/addons/gdUnit3/src/GdUnitAwaiter.gd
@@ -10,11 +10,11 @@ extends Reference
 static func await_signal_on(test_suite :WeakRef, source :Object, signal_name :String, args :Array = [], timeout_millis :int = 2000) -> GDScriptFunctionState:
 	var line_number := GdUnitAssertImpl._get_line_number();
 	var awaiter = GdUnitSignalAwaiter.new(timeout_millis)
-	yield(awaiter.on_signal(source, signal_name, args), "completed")
+	var value = yield(awaiter.on_signal(source, signal_name, args), "completed")
 	if awaiter.is_interrupted():
 		var failure = "await_signal_on(%s, %s) timed out after %sms" % [signal_name, args, timeout_millis]
 		GdUnitAssertImpl.new(test_suite.get_ref(), signal_name).report_error(failure, line_number)
-	return
+	return value
 
 # Waits for a specified signal sent from the <source> between idle frames and aborts with an error after the specified timeout has elapsed
 # source: the object from which the signal is emitted

--- a/addons/gdUnit3/src/core/GdUnitSignalAwaiter.gd
+++ b/addons/gdUnit3/src/core/GdUnitSignalAwaiter.gd
@@ -50,11 +50,13 @@ func on_signal(source :Object, signal_name :String, expected_signal_args :Array)
 	sleep.connect("timeout", self, "_on_sleep_awakening")
 	sleep.start(sleep_time)
 	
+	# holds the emited value
+	var value
 	# wait for signal is emitted or a timeout is happen
 	while true:
 		if _wait_on_idle_frame:
 			yield(Engine.get_main_loop(), "idle_frame")
-		var value = yield(self, "signal_emitted")
+		value = yield(self, "signal_emitted")
 		if value is Reference and value == TIMER_INTERRUPTED:
 			_interrupted = true
 			break
@@ -73,3 +75,6 @@ func on_signal(source :Object, signal_name :String, expected_signal_args :Array)
 	sleep.stop()
 	Engine.get_main_loop().root.remove_child(sleep)
 	sleep.free()
+	if value is Array and value.size() == 1:
+		return value[0]
+	return value

--- a/addons/gdUnit3/test/core/GdUnitSignalAwaiterTest.gd
+++ b/addons/gdUnit3/test/core/GdUnitSignalAwaiterTest.gd
@@ -1,0 +1,43 @@
+# GdUnit generated TestSuite
+#warning-ignore-all:unused_argument
+#warning-ignore-all:return_value_discarded
+class_name GdUnitSignalAwaiterTest
+extends GdUnitTestSuite
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit3/src/core/GdUnitSignalAwaiter.gd'
+
+
+class Monster extends Node:
+	
+	signal move(value)
+	signal slide(value, x, z )
+	
+	var _pos :float = 0.0
+	
+	func _process(_delta):
+		_pos += 0.2
+		emit_signal("move", _pos)
+		emit_signal("slide", _pos, 1 , 2)
+
+func test_on_signal_with_single_arg() -> void:
+	var monster = auto_free(Monster.new())
+	add_child(monster)
+	var signal_arg = yield(await_signal_on(monster, "move", [1.0]), "completed")
+	assert_float(signal_arg).is_equal(1.0)
+	remove_child(monster)
+
+func test_on_signal_with_many_args() -> void:
+	var monster = auto_free(Monster.new())
+	add_child(monster)
+	var signal_args = yield(await_signal_on(monster, "slide", [1.0, 1, 2]), "completed")
+	assert_array(signal_args).is_equal([1.0, 1, 2])
+	remove_child(monster)
+
+func test_on_signal_fail() -> void:
+	GdAssertReports.expect_fail()
+	var monster = auto_free(Monster.new())
+	add_child(monster)
+	var signal_args = yield(await_signal_on(monster, "move", [4.0]), "completed")
+	assert_str(GdAssertReports.current_failure()).is_equal("await_signal_on(move, [4]) timed out after 2000ms")
+	remove_child(monster)

--- a/project.godot
+++ b/project.godot
@@ -729,6 +729,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gdUnit3/src/core/GdUnitSignalAwaiter.gd"
 }, {
+"base": "GdUnitTestSuite",
+"class": "GdUnitSignalAwaiterTest",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/test/core/GdUnitSignalAwaiterTest.gd"
+}, {
 "base": "Resource",
 "class": "GdUnitSingleton",
 "language": "GDScript",
@@ -1304,6 +1309,7 @@ _global_script_class_icons={
 "GdUnitSignalAssertImpl": "",
 "GdUnitSignalAssertImplTest": "",
 "GdUnitSignalAwaiter": "",
+"GdUnitSignalAwaiterTest": "",
 "GdUnitSingleton": "",
 "GdUnitSpyBuilder": "",
 "GdUnitSpyBuilderTest": "",


### PR DESCRIPTION
- the emited signal value was not returned ans is now transport to the caller