### PR TITLE
GD-291: Spy fails for class with custom formatted function signature

### DIFF
--- a/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
@@ -23,6 +23,7 @@ static func _get_line_number() -> int:
 		 or source.ends_with("AssertImpl.gd") \
 		 or source.ends_with("GdUnitTestSuite.gd") \
 		 or source.ends_with("GdUnitSceneRunnerImpl.gd") \
+		 or source.ends_with("GdUnitObjectInteractions.gd") \
 		 or source.ends_with("GdUnitAwaiter.gd"):
 			continue
 		return stack_info.get("line")

--- a/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
@@ -319,6 +319,20 @@ func test_extract_source_code_inner_class_Area4D():
 	var file_content := resource_as_array("res://addons/gdUnit3/test/core/resources/Area4D.txt")
 	assert_array(rows).contains_exactly(file_content)
 
+func test_extract_function_signature() -> void:
+	var path := GdObjects.extract_class_path("res://addons/gdUnit3/test/mocker/resources/ClassWithCustomFormattings.gd")
+	var rows = _parser.extract_source_code(path)
+	
+	assert_that(_parser.extract_func_signature(rows, 5))\
+		.is_equal("funca1(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false)->void:")
+	assert_that(_parser.extract_func_signature(rows, 10))\
+		.is_equal("funca2(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false)->void:")
+	assert_that(_parser.extract_func_signature(rows, 15))\
+		.is_equal("funca3(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false):")
+	assert_that(_parser.extract_func_signature(rows, 20))\
+		.is_equal("funca4(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false):")
+
+
 func test_strip_leading_spaces():
 	assert_str(GdScriptParser.TokenInnerClass._strip_leading_spaces("")).is_empty()
 	assert_str(GdScriptParser.TokenInnerClass._strip_leading_spaces(" ")).is_empty()

--- a/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
@@ -323,13 +323,13 @@ func test_extract_function_signature() -> void:
 	var path := GdObjects.extract_class_path("res://addons/gdUnit3/test/mocker/resources/ClassWithCustomFormattings.gd")
 	var rows = _parser.extract_source_code(path)
 	
-	assert_that(_parser.extract_func_signature(rows, 5))\
+	assert_that(_parser.extract_func_signature(rows, 9))\
 		.is_equal("funca1(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false)->void:")
-	assert_that(_parser.extract_func_signature(rows, 10))\
+	assert_that(_parser.extract_func_signature(rows, 14))\
 		.is_equal("funca2(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false)->void:")
-	assert_that(_parser.extract_func_signature(rows, 15))\
+	assert_that(_parser.extract_func_signature(rows, 19))\
 		.is_equal("funca3(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false):")
-	assert_that(_parser.extract_func_signature(rows, 20))\
+	assert_that(_parser.extract_func_signature(rows, 24))\
 		.is_equal("funca4(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false):")
 
 

--- a/addons/gdUnit3/test/mocker/resources/ClassWithCustomFormattings.gd
+++ b/addons/gdUnit3/test/mocker/resources/ClassWithCustomFormattings.gd
@@ -1,7 +1,11 @@
 extends Object
 
-func message() -> String:
-	return "a message"
+var _message
+
+func _init(message:String, path:String="", load_on_init:bool=false, 
+	set_auto_save:bool=false, set_network_sync:bool=false
+) -> void:
+	_message = message
 
 func a1(set_name:String, path:String="", load_on_init:bool=false, 
 	set_auto_save:bool=false, set_network_sync:bool=false

--- a/addons/gdUnit3/test/mocker/resources/ClassWithCustomFormattings.gd
+++ b/addons/gdUnit3/test/mocker/resources/ClassWithCustomFormattings.gd
@@ -1,0 +1,27 @@
+extends Object
+
+func message() -> String:
+	return "a message"
+
+func a1(set_name:String, path:String="", load_on_init:bool=false, 
+	set_auto_save:bool=false, set_network_sync:bool=false
+) -> void:
+	pass
+
+func a2(set_name:String, path:String="", load_on_init:bool=false, 
+	set_auto_save:bool=false, set_network_sync:bool=false
+) -> 	void:
+	pass
+
+func a3(set_name:String, path:String="", load_on_init:bool=false, 
+	set_auto_save:bool=false, set_network_sync:bool=false
+) :
+	pass
+
+func a4(set_name:String,
+	path:String="",
+	load_on_init:bool=false,
+	set_auto_save:bool=false,
+	set_network_sync:bool=false
+):
+	pass

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -102,7 +102,7 @@ func test_spy_class_with_custom_formattings() -> void:
 	verify(spy, 1).a1("set_name", "", true)
 	verify_no_more_interactions(spy)
 	verify_no_interactions(spy, GdUnitAssert.EXPECT_FAIL)
-	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(105)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(104)
 
 func test_spy_copied_class_members():
 	var instance = auto_free(load("res://addons/gdUnit3/test/mocker/resources/TestPersion.gd").new("user-x", "street", 56616))

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -94,14 +94,15 @@ func test_spy_on_custom_class():
 	# verify if a not used argument not counted
 	verify(spy_instance, 0).get_area("test_no")
 
-
 # GD-291 https://github.com/MikeSchulze/gdUnit3/issues/291
 func test_spy_class_with_custom_formattings() -> void:
 	var resource = load("res://addons/gdUnit3/test/mocker/resources/ClassWithCustomFormattings.gd")
-	var instance :Object = resource.new()
-	var spy = spy(instance)
+	var spy = spy(resource.new("test"))
 	spy.a1("set_name", "", true)
 	verify(spy, 1).a1("set_name", "", true)
+	verify_no_more_interactions(spy)
+	verify_no_interactions(spy, GdUnitAssert.EXPECT_FAIL)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(105)
 
 func test_spy_copied_class_members():
 	var instance = auto_free(load("res://addons/gdUnit3/test/mocker/resources/TestPersion.gd").new("user-x", "street", 56616))

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -94,6 +94,15 @@ func test_spy_on_custom_class():
 	# verify if a not used argument not counted
 	verify(spy_instance, 0).get_area("test_no")
 
+
+# GD-291 https://github.com/MikeSchulze/gdUnit3/issues/291
+func test_spy_class_with_custom_formattings() -> void:
+	var resource = load("res://addons/gdUnit3/test/mocker/resources/ClassWithCustomFormattings.gd")
+	var instance :Object = resource.new()
+	var spy = spy(instance)
+	spy.a1("set_name", "", true)
+	verify(spy, 1).a1("set_name", "", true)
+
 func test_spy_copied_class_members():
 	var instance = auto_free(load("res://addons/gdUnit3/test/mocker/resources/TestPersion.gd").new("user-x", "street", 56616))
 	assert_that(instance._name).is_equal("user-x")


### PR DESCRIPTION
- spy was failing to parse the function signature for custom formatted functions
- scans now until end of function to collect the complete function signature
- fix error line detection for `verify_no_interactions` and `verify_no_more_interactions`