### PR TITLE
GD-295: Add `CI-PR` workflow to run on pull requests

### DIFF
--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -5,11 +5,16 @@ inputs:
   godot-version:
     description: "The Godot Engine version to run"
     required: true
+outputs:
+  path:
+    description: "The Godot executable path"
+    value: ${{ steps.install.path }}
 
 runs:
   using: composite
   steps:
     - name: Install Godot ${{ inputs.godot-version }}
+      id : install
       continue-on-error: false
       shell: bash
       run: |
@@ -17,3 +22,5 @@ runs:
         wget https://downloads.tuxfamily.org/godotengine/${{ inputs.godot-version }}/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip -P /usr/local/bin/godot
         unzip /usr/local/bin/godot/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip
         rm /usr/local/bin/godot/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip
+        chmod 770 /usr/local/bin/godot/Godot.app/Contents/MacOS/Godot
+        echo "::set-output name=path::'/usr/local/bin/godot/Godot.app/Contents/MacOS/Godot'"

--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -20,7 +20,8 @@ runs:
       run: |
         mkdir /usr/local/bin/godot
         wget https://downloads.tuxfamily.org/godotengine/${{ inputs.godot-version }}/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip -P /usr/local/bin/godot
-        unzip /usr/local/bin/godot/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip
+        unzip /usr/local/bin/godot/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip -d /usr/local/bin/godot/
         rm /usr/local/bin/godot/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip
+        ls -lsR /usr/local/bin/godot
         chmod 770 /usr/local/bin/godot/Godot.app/Contents/MacOS/Godot
         echo "::set-output name=path::'/usr/local/bin/godot/Godot.app/Contents/MacOS/Godot'"

--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -11,5 +11,8 @@ runs:
   steps:
     - name: Install Godot ${{ inputs.godot-version }}
       continue-on-error: false
-      container:
-        image: barichello/godot-ci:${{ inputs.godot-version }}
+      run:
+        mkdir /usr/local/bin/godot
+        wget https://downloads.tuxfamily.org/godotengine/${inputs.godot-version}/Godot_v${inputs.godot-version}-stable_osx.universal.zip -P /usr/local/bin/godot
+        unzip /usr/local/bin/godot/Godot_v${inputs.godot-version}-stable_osx.universal.zip
+        rm /usr/local/bin/godot/Godot_v${inputs.godot-version}-stable_osx.universal.zip

--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -14,6 +14,6 @@ runs:
       shell: bash
       run:
         mkdir /usr/local/bin/godot
-        wget https://downloads.tuxfamily.org/godotengine/${inputs.godot-version}/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip -P /usr/local/bin/godot
+        wget https://downloads.tuxfamily.org/godotengine/${{ inputs.godot-version }}/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip -P /usr/local/bin/godot
         unzip /usr/local/bin/godot/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip
         rm /usr/local/bin/godot/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip

--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -10,7 +10,6 @@ runs:
   using: composite
   steps:
     - name: Install Godot ${{ inputs.godot-version }}
-      runs-on: ubuntu-latest
       continue-on-error: false
       container:
         image: barichello/godot-ci:${{ inputs.godot-version }}

--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -11,6 +11,7 @@ runs:
   steps:
     - name: Install Godot ${{ inputs.godot-version }}
       continue-on-error: false
+      shell: bash
       run:
         mkdir /usr/local/bin/godot
         wget https://downloads.tuxfamily.org/godotengine/${inputs.godot-version}/Godot_v${inputs.godot-version}-stable_osx.universal.zip -P /usr/local/bin/godot

--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Install Godot ${{ inputs.godot-version }}
       continue-on-error: false
       shell: bash
-      run:
+      run: |
         mkdir /usr/local/bin/godot
         wget https://downloads.tuxfamily.org/godotengine/${{ inputs.godot-version }}/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip -P /usr/local/bin/godot
         unzip /usr/local/bin/godot/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip

--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -1,0 +1,16 @@
+name: install-godot-image
+description: "Installs the Godot image"
+
+inputs:
+  godot-version:
+    description: "The Godot Engine version to run"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Godot ${{ inputs.godot-version }}
+      runs-on: ubuntu-latest
+      continue-on-error: false
+      container:
+        image: barichello/godot-ci:${{ inputs.godot-version }}

--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -5,10 +5,6 @@ inputs:
   godot-version:
     description: "The Godot Engine version to run"
     required: true
-outputs:
-  path:
-    description: "The Godot executable path"
-    value: ${{ steps.install.path }}
 
 runs:
   using: composite
@@ -16,6 +12,8 @@ runs:
     - name: Install Godot ${{ inputs.godot-version }}
       id : install
       continue-on-error: false
+      env:
+          GODOT_BIN: /usr/local/bin/godot/Godot.app/Contents/MacOS/Godot
       shell: bash
       run: |
         mkdir /usr/local/bin/godot
@@ -24,4 +22,3 @@ runs:
         rm /usr/local/bin/godot/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip
         ls -lsR /usr/local/bin/godot
         chmod 770 /usr/local/bin/godot/Godot.app/Contents/MacOS/Godot
-        echo "::set-output name=path::'/usr/local/bin/godot/Godot.app/Contents/MacOS/Godot'"

--- a/.github/actions/install-godot/action.yml
+++ b/.github/actions/install-godot/action.yml
@@ -14,6 +14,6 @@ runs:
       shell: bash
       run:
         mkdir /usr/local/bin/godot
-        wget https://downloads.tuxfamily.org/godotengine/${inputs.godot-version}/Godot_v${inputs.godot-version}-stable_osx.universal.zip -P /usr/local/bin/godot
-        unzip /usr/local/bin/godot/Godot_v${inputs.godot-version}-stable_osx.universal.zip
-        rm /usr/local/bin/godot/Godot_v${inputs.godot-version}-stable_osx.universal.zip
+        wget https://downloads.tuxfamily.org/godotengine/${inputs.godot-version}/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip -P /usr/local/bin/godot
+        unzip /usr/local/bin/godot/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip
+        rm /usr/local/bin/godot/Godot_v${{ inputs.godot-version }}-stable_osx.universal.zip

--- a/.github/actions/publish-test-report/action.yml
+++ b/.github/actions/publish-test-report/action.yml
@@ -12,6 +12,6 @@ runs:
     - name: Publish Test Results 
       uses: dorny/test-reporter@v1
       with:
-        name: ${{ inputs.report-name }}
+        name: test_report_${{ inputs.report-name }}
         path: 'reports/**/results.xml'
         reporter: java-junit

--- a/.github/actions/publish-test-report/action.yml
+++ b/.github/actions/publish-test-report/action.yml
@@ -15,3 +15,4 @@ runs:
         name: test_report_${{ inputs.report-name }}
         path: 'reports/**/results.xml'
         reporter: java-junit
+        fail-on-error: 'false'

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -16,4 +16,3 @@ runs:
         GODOT_BIN: ${{ inputs.godot-bin }}
       shell: bash
       run: ./runtest.sh --add ${{ inputs.test-includes }} --continue
-   

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -5,13 +5,15 @@ inputs:
   test-includes:
     description: "Paths to include for test run"
     required: true
+  godot-bin:
+    required: true
 
 runs:
   using: composite
   steps:
     - name: "Unit Test"
       env:
-        GODOT_BIN: "/usr/local/bin/godot"
+        GODOT_BIN: ${{ inputs.godot-bin }}
       shell: bash
       run: ./runtest.sh --add ${{ inputs.test-includes }} --continue
    

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -1,0 +1,17 @@
+name: unit-test
+description: "Run unit tests for GdUnit3 API"
+
+inputs:
+  test-includes:
+    description: "Paths to include for test run"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: "Unit Test"
+      env:
+        GODOT_BIN: "/usr/local/bin/godot"
+      shell: bash
+      run: ./runtest.sh --add ${{ inputs.test-includes }} --continue
+   

--- a/.github/actions/upload-test-report/action.yml
+++ b/.github/actions/upload-test-report/action.yml
@@ -1,0 +1,16 @@
+name: upload-test-report
+description: "Uploads the GdUnit test reports"
+
+inputs:
+  report-name:
+    description: "Name of the report to be upload."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Collect Test Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: test_report_${{ inputs.report-name }}
+        path: reports/**     

--- a/.github/actions/upload-test-report/action.yml
+++ b/.github/actions/upload-test-report/action.yml
@@ -13,4 +13,4 @@ runs:
       uses: actions/upload-artifact@v2
       with:
         name: test_report_${{ inputs.report-name }}
-        path: reports/**     
+        path: reports/**

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -35,7 +35,6 @@ jobs:
     continue-on-error: false
     outputs:
       godot-version: ${{ matrix.godot-version }}
-      godot-path: ${{ steps.install-godot.outputs.path }}
       system: ${{ matrix.system }}
 
     steps:
@@ -56,7 +55,7 @@ jobs:
         if: ${{ !cancelled() }}
         timeout-minutes: 3
         run: |
-          ${{ outputs.godot-path }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window -v
+          ${{ steps.install-godot.outputs.path }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window -v
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -38,6 +38,11 @@ jobs:
       system: ${{ matrix.system }}
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: "Install Godot image ${{ matrix.godot-version }}"
         uses: ./.github/actions/install-godot
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -46,7 +46,6 @@ jobs:
         if: ${{ !cancelled() }}
         timeout-minutes: 1
         run: |
-          ls -lsR .
           ${{ env.GODOT_BIN }} -e --path project.godot res://addons/gdUnit3/scan_project.tscn --no-window
 
       - name: "Unit Test"
@@ -75,35 +74,7 @@ jobs:
         with:
           report-name: ${{ matrix.godot-version }}
 
-  compile-mono:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    continue-on-error: false
-    container:
-      image: barichello/godot-ci:mono-3.4.4
-
-    steps:
-      - name: "Checkout"
-        if: ${{ !cancelled() }}
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-          submodules: 'recursive'
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 6.0.x
-
-      - name: Compile
-        run: |
-          dotnet restore gdUnit3.csproj
-          mkdir -p .mono/assemblies/Debug
-          cp /usr/local/bin/GodotSharp/Api/Release/* .mono/assemblies/Debug
-          dotnet build -verbosity:m
-
   mono-uint-test:
-    needs: compile-mono
     strategy:
       fail-fast: false
       matrix:
@@ -123,6 +94,18 @@ jobs:
         with:
           lfs: true
           submodules: 'recursive'
+
+      - name: "Setup .NET"
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
+      - name: "Compile"
+        run: |
+          dotnet restore gdUnit3.csproj
+          mkdir -p .mono/assemblies/Debug
+          cp /usr/local/bin/GodotSharp/Api/Release/* .mono/assemblies/Debug
+          dotnet build -verbosity:m
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  GODOT_BIN: "/usr/local/bin/godot"
+  GODOT_BIN: "/usr/local/bin/godot/Godot.app/Contents/MacOS/Godot"
 
 concurrency:
   group: ci-pr-${{ github.event.number }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system: [macos-latest]
+        system: [macos-11]
         godot-version: [3.4.1, 3.4.2, 3.4.4]
 
     name: "CI Godot ${{ matrix.godot-version }}"
@@ -62,6 +62,7 @@ jobs:
         timeout-minutes: 10
         uses: ./.github/actions/unit-test
         with:
+          godot-bin: ${{ env.GODOT_BIN }}
           test-includes: "res://addons/gdUnit3/test/"
 
       - name: "Unit Test Examples"
@@ -69,6 +70,7 @@ jobs:
         timeout-minutes: 5
         uses: ./.github/actions/unit-test
         with:
+          godot-bin: ${{ env.GODOT_BIN }}
           test-includes: "res://gdUnit3-examples"
 
       - name: "Publish Unit Test Reports"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -27,18 +27,18 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: "Install Godot Image"
-        if: ${{ !cancelled() }}
-        uses: ./.github/actions/install-godot
-        with:
-          godot-version: ${{ matrix.godot-version }}
-
       - name: "Checkout"
         if: ${{ !cancelled() }}
         uses: actions/checkout@v3
         with:
           lfs: true
           submodules: 'recursive'
+
+      - name: "Install Godot Image"
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/install-godot
+        with:
+          godot-version: ${{ matrix.godot-version }}
 
       - name: "Unit Test"
         id: selft-test

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -26,7 +26,7 @@ jobs:
 
     name: "CI Godot ${{ matrix.godot-version }}"
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     continue-on-error: false
     container:
       image: barichello/godot-ci:${{ matrix.godot-version }}
@@ -40,14 +40,15 @@ jobs:
           submodules: 'recursive'
 
       - name: "Unit Test"
-        id: selft-test
         if: ${{ !cancelled() }}
+        timeout-minutes: 10
         uses: ./.github/actions/unit-test
         with:
           test-includes: "res://addons/gdUnit3/test/"
 
       - name: "Unit Test Examples"
         if: ${{ !cancelled() }}
+        timeout-minutes: 5
         uses: ./.github/actions/unit-test
         with:
           test-includes: "res://gdUnit3-examples"
@@ -72,7 +73,7 @@ jobs:
 
     name: "CI Godot ${{ matrix.godot-version }}"
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     continue-on-error: false
     container:
       image: barichello/godot-ci:${{ matrix.godot-version }}
@@ -98,6 +99,7 @@ jobs:
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}
+        timeout-minutes: 15
         uses: ./.github/actions/unit-test
         with:
           test-includes: "res://addons/gdUnit3/test/"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -47,7 +47,6 @@ jobs:
           test-includes: "res://addons/gdUnit3/test/"
 
       - name: "Unit Test Examples"
-        id: selft-test
         if: ${{ !cancelled() }}
         uses: ./.github/actions/unit-test
         with:
@@ -87,7 +86,6 @@ jobs:
           submodules: 'recursive'
 
       - name: "Unit Test"
-        id: selft-test
         if: ${{ !cancelled() }}
         uses: ./.github/actions/unit-test
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        godot-version: [3.4.1, 3.4.2, 3.4.4]
+        godot-version: [3.4.1, 3.4.2, 3.4.4, mono-3.4.1, mono-3.4.2, mono-3.4.4]
 
     name: "CI Godot ${{ matrix.godot-version }}"
     runs-on: ubuntu-latest
@@ -47,9 +47,23 @@ jobs:
       - name: "Update Project"
         if: ${{ !cancelled() }}
         timeout-minutes: 1
-        continue-on-error: true
+        continue-on-error: true # we still ignore the timeout, the script is not quit and we run into a timeout
         run: |
           ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window
+
+      - name: "Setup .NET"
+        if: startsWith( ${{ matrix.godot-version }}, "mono" )
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
+      - name: "Compile"
+        if: startsWith( ${{ matrix.godot-version }}, "mono" )
+        run: |
+          dotnet restore gdUnit3.csproj
+          mkdir -p .mono/assemblies/Debug
+          cp /usr/local/bin/GodotSharp/Api/Release/* .mono/assemblies/Debug
+          dotnet build -verbosity:m
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ !cancelled() }}
         timeout-minutes: 1
         run: |
-          ${{ env.GODOT_BIN }} -e --path . res://addons/gdUnit3/scan_project.tscn --no-window
+          ${{ env.GODOT_BIN }} -e --path . res://addons/gdUnit3/scan_project.tscn --no-window --check-only
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -35,6 +35,7 @@ jobs:
     continue-on-error: false
     outputs:
       godot-version: ${{ matrix.godot-version }}
+      godot-path: ${{ steps.install-godot.outputs.path }}
       system: ${{ matrix.system }}
 
     steps:
@@ -45,6 +46,7 @@ jobs:
           submodules: 'recursive'
 
       - name: "Install Godot image ${{ matrix.godot-version }}"
+        id: install-godot
         timeout-minutes: 3
         uses: ./.github/actions/install-godot
         with:
@@ -54,7 +56,7 @@ jobs:
         if: ${{ !cancelled() }}
         timeout-minutes: 3
         run: |
-          ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window -v
+          ${{ outputs.godot-path }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window -v
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system: [macos-11]
+        system: [windows-latest]
         godot-version: [3.4.1, 3.4.2, 3.4.4]
 
     name: "CI Godot ${{ matrix.godot-version }}"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -28,7 +28,7 @@ jobs:
         godot-version: [3.4.1, 3.4.2, 3.4.4]
 
     name: "CI Godot ${{ matrix.godot-version }}"
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 20
     continue-on-error: false
     container:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -30,7 +30,7 @@ jobs:
 
     name: "CI Godot ${{ matrix.godot-version }}"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     continue-on-error: false
     container:
       image: barichello/godot-ci:${{ matrix.godot-version }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -74,6 +74,10 @@ jobs:
           report-name: ${{ matrix.godot-version }}
 
   compile-mono:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: false
+
     steps:
       - name: "Checkout"
         if: ${{ !cancelled() }}
@@ -93,7 +97,6 @@ jobs:
           mkdir -p .mono/assemblies/Debug
           cp /usr/local/bin/GodotSharp/Api/Release/* .mono/assemblies/Debug
           dotnet build -verbosity:m
-
 
   mono-uint-test:
     needs: compile-mono

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  GODOT_BIN: "/usr/local/bin/godot/Godot.app/Contents/MacOS/Godot"
+  GODOT_BIN: "/usr/local/bin/godot"
 
 concurrency:
   group: ci-pr-${{ github.event.number }}
@@ -26,16 +26,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system: [windows-latest]
         godot-version: [3.4.1, 3.4.2, 3.4.4]
 
     name: "CI Godot ${{ matrix.godot-version }}"
-    runs-on: ${{ matrix.system }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: false
+    container:
+      image: barichello/godot-ci:${{ matrix.godot-version }}
     outputs:
       godot-version: ${{ matrix.godot-version }}
-      system: ${{ matrix.system }}
 
     steps:
       - name: checkout
@@ -44,16 +44,9 @@ jobs:
           lfs: true
           submodules: 'recursive'
 
-      - name: "Install Godot image ${{ matrix.godot-version }}"
-        id: install-godot
-        timeout-minutes: 3
-        uses: ./.github/actions/install-godot
-        with:
-          godot-version: ${{ matrix.godot-version }}
-
       - name: "Update Project"
         if: ${{ !cancelled() }}
-        timeout-minutes: 3
+        timeout-minutes: 1
         run: |
           ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window -v
 
@@ -67,7 +60,7 @@ jobs:
 
       - name: "Unit Test Examples"
         if: ${{ !cancelled() }}
-        timeout-minutes: 5
+        timeout-minutes: 1
         uses: ./.github/actions/unit-test
         with:
           godot-bin: ${{ env.GODOT_BIN }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           report-name: ${{ matrix.godot-version }}
 
- mono-uint-test:
+  mono-uint-test:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -85,6 +85,17 @@ jobs:
           lfs: true
           submodules: 'recursive'
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Compile
+        run: |
+          dotnet restore gdUnit3.csproj
+          mkdir -p .mono/assemblies/Debug
+          cp /usr/local/bin/GodotSharp
+
       - name: "Unit Test"
         if: ${{ !cancelled() }}
         uses: ./.github/actions/unit-test

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -30,7 +30,7 @@ jobs:
         godot-version: [3.4.1, 3.4.2, 3.4.4]
 
     name: "CI Godot ${{ matrix.godot-version }}"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.system }}
     timeout-minutes: 5
     continue-on-error: false
     outputs:
@@ -51,7 +51,6 @@ jobs:
           godot-version: ${{ matrix.godot-version }}
 
       - name: "Update Project"
-        runs-on: ${{ matrix.system }}
         if: ${{ !cancelled() }}
         timeout-minutes: 3
         run: |

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
 
-  install_godot:
+  gd-uint-test:
     strategy:
       fail-fast: false
       matrix:
@@ -41,30 +41,17 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          lfs: true
+          submodules: 'recursive'
 
       - name: "Install Godot image ${{ matrix.godot-version }}"
+        timeout-minutes: 3
         uses: ./.github/actions/install-godot
         with:
           godot-version: ${{ matrix.godot-version }}
 
-
-  gd-uint-test:
-    needs: install_godot
-    name: "CI Godot ${{ needs.install_godot.outputs.godot-version }}"
-    runs-on: ${{ needs.install_godot.outputs.system }}
-    timeout-minutes: 10
-    continue-on-error: false
-
-    steps:
-      - name: "Checkout"
-        if: ${{ !cancelled() }}
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-          submodules: 'recursive'
-
       - name: "Update Project"
+        runs-on: ${{ matrix.system }}
         if: ${{ !cancelled() }}
         timeout-minutes: 3
         run: |
@@ -88,13 +75,13 @@ jobs:
         if: ${{ !cancelled() }}
         uses: ./.github/actions/publish-test-report
         with:
-          report-name: ${{ needs.install_godot.outputs.godot-version }}
+          report-name: ${{ matrix.godot-version }}
 
       - name: "Upload Unit Test Reports"
         if: ${{ !cancelled() }}
         uses: ./.github/actions/upload-test-report
         with:
-          report-name: ${{ needs.install_godot.outputs.godot-version }}
+          report-name: ${{ matrix.godot-version }}
 
   mono-uint-test:
     if: ${{ false }}  # disable for now

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -23,8 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         godot-version: [3.4.1, 3.4.2, 3.4.4]
+
+    name: "CI Godot ${{ matrix.godot-version }}"
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: false
+    container:
+      image: barichello/godot-ci:${{ matrix.godot-version }}
 
     steps:
       - name: "Checkout"
@@ -33,12 +38,6 @@ jobs:
         with:
           lfs: true
           submodules: 'recursive'
-
-      - name: "Install Godot Image"
-        if: ${{ !cancelled() }}
-        uses: ./.github/actions/install-godot
-        with:
-          godot-version: ${{ matrix.godot-version }}
 
       - name: "Unit Test"
         id: selft-test

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -49,7 +49,7 @@ jobs:
         timeout-minutes: 1
         continue-on-error: true
         run: |
-          ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window -v
+          ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -30,15 +30,15 @@ jobs:
       - name: "Install Godot Image"
         if: ${{ !cancelled() }}
         uses: ./.github/actions/install-godot
-          with:
-            godot-version: ${{ matrix.godot-version }}
+        with:
+          godot-version: ${{ matrix.godot-version }}
 
       - name: "Checkout"
         if: ${{ !cancelled() }}
         uses: actions/checkout@v3
-          with:
-            lfs: true
-            submodules: 'recursive'
+        with:
+          lfs: true
+          submodules: 'recursive'
 
       - name: "Unit Test"
         id: selft-test

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -46,6 +46,53 @@ jobs:
         with:
           test-includes: "res://addons/gdUnit3/test/"
 
+      - name: "Unit Test Examples"
+        id: selft-test
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/unit-test
+        with:
+          test-includes: "res://gdUnit3-examples"
+
+      - name: "Publish Unit Test Reports"
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/publish-test-report
+        with:
+          report-name: ${{ matrix.godot-version }}
+
+      - name: "Upload Unit Test Reports"
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/upload-test-report
+        with:
+          report-name: ${{ matrix.godot-version }}
+
+ mono-uint-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        godot-version: [mono-3.3.3, mono-3.3.4, mono-3.4.1, mono-3.4.2, mono-3.4.4]
+
+    name: "CI Godot ${{ matrix.godot-version }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: false
+    container:
+      image: barichello/godot-ci:${{ matrix.godot-version }}
+
+    steps:
+      - name: "Checkout"
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: 'recursive'
+
+      - name: "Unit Test"
+        id: selft-test
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/unit-test
+        with:
+          test-includes: "res://addons/gdUnit3/test/"
+
       - name: "Publish Unit Test Reports"
         if: ${{ !cancelled() }}
         uses: ./.github/actions/publish-test-report

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ !cancelled() }}
         timeout-minutes: 3
         run: |
-          ${{ env.GODOT_BIN }} -e --path . res://addons/gdUnit3/scan_project.tscn --no-window -v
+          ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window -v
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -47,6 +47,7 @@ jobs:
       - name: "Update Project"
         if: ${{ !cancelled() }}
         timeout-minutes: 1
+        continue-on-error: true
         run: |
           ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window -v
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
 
-  gd-uint-test:
+  unit-test:
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +38,7 @@ jobs:
       godot-version: ${{ matrix.godot-version }}
 
     steps:
-      - name: checkout
+      - name: "Checkout Repository"
         uses: actions/checkout@v3
         with:
           lfs: true
@@ -52,20 +52,20 @@ jobs:
           ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window
 
       - name: "Setup .NET"
-        if: ${{ startsWith( matrix.godot-version, 'mono') }}
+        if: ${{ startsWith( matrix.godot-version, 'mono') }} # we only setup .Net for mono versions
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.x
 
-      - name: "Compile"
-        if: ${{ startsWith( matrix.godot-version, 'mono') }}
+      - name: "Compile C#"
+        if: ${{ startsWith( matrix.godot-version, 'mono') }} # we only compile .Net for mono versions
         run: |
           dotnet restore gdUnit3.csproj
           mkdir -p .mono/assemblies/Debug
           cp /usr/local/bin/GodotSharp/Api/Release/* .mono/assemblies/Debug
           dotnet build -verbosity:m
 
-      - name: "Unit Test"
+      - name: "Run Unit Test"
         if: ${{ !cancelled() }}
         timeout-minutes: 10
         uses: ./.github/actions/unit-test
@@ -73,66 +73,13 @@ jobs:
           godot-bin: ${{ env.GODOT_BIN }}
           test-includes: "res://addons/gdUnit3/test/"
 
-      - name: "Unit Test Examples"
+      - name: "Run Unit Test Examples"
         if: ${{ !cancelled() }}
         timeout-minutes: 1
         uses: ./.github/actions/unit-test
         with:
           godot-bin: ${{ env.GODOT_BIN }}
           test-includes: "res://gdUnit3-examples"
-
-      - name: "Publish Unit Test Reports"
-        if: ${{ !cancelled() }}
-        uses: ./.github/actions/publish-test-report
-        with:
-          report-name: ${{ matrix.godot-version }}
-
-      - name: "Upload Unit Test Reports"
-        if: ${{ !cancelled() }}
-        uses: ./.github/actions/upload-test-report
-        with:
-          report-name: ${{ matrix.godot-version }}
-
-  mono-uint-test:
-    if: ${{ false }}  # disable for now
-    strategy:
-      fail-fast: false
-      matrix:
-        godot-version: [mono-3.3.3, mono-3.3.4, mono-3.4.1, mono-3.4.2, mono-3.4.4]
-
-    name: "CI Godot ${{ matrix.godot-version }}"
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    continue-on-error: false
-    container:
-      image: barichello/godot-ci:${{ matrix.godot-version }}
-
-    steps:
-      - name: "Checkout"
-        if: ${{ !cancelled() }}
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-          submodules: 'recursive'
-
-      - name: "Setup .NET"
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 6.0.x
-
-      - name: "Compile"
-        run: |
-          dotnet restore gdUnit3.csproj
-          mkdir -p .mono/assemblies/Debug
-          cp /usr/local/bin/GodotSharp/Api/Release/* .mono/assemblies/Debug
-          dotnet build -verbosity:m
-
-      - name: "Unit Test"
-        if: ${{ !cancelled() }}
-        timeout-minutes: 15
-        uses: ./.github/actions/unit-test
-        with:
-          test-includes: "res://addons/gdUnit3/test/"
 
       - name: "Publish Unit Test Reports"
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -52,13 +52,13 @@ jobs:
           ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window
 
       - name: "Setup .NET"
-        if: startsWith( ${{ matrix.godot-version }}, "mono" )
+        if: ${{ startsWith( matrix.godot-version, 'mono') }}
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.x
 
       - name: "Compile"
-        if: startsWith( ${{ matrix.godot-version }}, "mono" )
+        if: ${{ startsWith( matrix.godot-version, 'mono') }}
         run: |
           dotnet restore gdUnit3.csproj
           mkdir -p .mono/assemblies/Debug

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ !cancelled() }}
         timeout-minutes: 1
         run: |
-          ${{ env.GODOT_BIN }} -e --path project.godot res://addons/gdUnit3/scan_project.tscn --no-window
+          ${{ env.GODOT_BIN }} -e --path . res://addons/gdUnit3/scan_project.tscn --no-window
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -44,9 +44,9 @@ jobs:
 
       - name: "Update Project"
         if: ${{ !cancelled() }}
-        timeout-minutes: 1
+        timeout-minutes: 3
         run: |
-          ${{ env.GODOT_BIN }} -e --path . res://addons/gdUnit3/scan_project.tscn --no-window -d --quiet
+          ${{ env.GODOT_BIN }} -e --path . res://addons/gdUnit3/scan_project.tscn --no-window --quiet
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -44,7 +44,9 @@ jobs:
 
       - name: "Update Project"
         if: ${{ !cancelled() }}
+        timeout-minutes: 1
         run: |
+          ls -lsR .
           ${{ env.GODOT_BIN }} -e --path project.godot res://addons/gdUnit3/scan_project.tscn --no-window
 
       - name: "Unit Test"
@@ -77,6 +79,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: false
+    container:
+      image: barichello/godot-ci:mono-3.4.4
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -21,18 +21,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  gd-uint-test:
+
+  install_godot:
     strategy:
       fail-fast: false
       matrix:
+        system: [macos-latest]
         godot-version: [3.4.1, 3.4.2, 3.4.4]
 
     name: "CI Godot ${{ matrix.godot-version }}"
-    runs-on: macos-latest
-    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     continue-on-error: false
-    container:
-      image: barichello/godot-ci:${{ matrix.godot-version }}
+    outputs:
+      godot-version: ${{ matrix.godot-version }}
+      system: ${{ matrix.system }}
+
+    steps:
+      - name: "Install Godot image ${{ matrix.godot-version }}"
+        uses: ./.github/actions/install-godot
+        with:
+          godot-version: ${{ matrix.godot-version }}
+
+
+  gd-uint-test:
+    needs: install_godot
+    name: "CI Godot ${{ needs.install_godot.outputs.godot-version }}"
+    runs-on: ${{ needs.install_godot.outputs.system }}
+    timeout-minutes: 10
+    continue-on-error: false
 
     steps:
       - name: "Checkout"
@@ -66,13 +83,13 @@ jobs:
         if: ${{ !cancelled() }}
         uses: ./.github/actions/publish-test-report
         with:
-          report-name: ${{ matrix.godot-version }}
+          report-name: ${{ needs.install_godot.outputs.godot-version }}
 
       - name: "Upload Unit Test Reports"
         if: ${{ !cancelled() }}
         uses: ./.github/actions/upload-test-report
         with:
-          report-name: ${{ matrix.godot-version }}
+          report-name: ${{ needs.install_godot.outputs.godot-version }}
 
   mono-uint-test:
     strategy:
@@ -89,6 +106,7 @@ jobs:
 
     steps:
       - name: "Checkout"
+        if: ${{ false }}  # disable for now
         if: ${{ !cancelled() }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -92,6 +92,7 @@ jobs:
           report-name: ${{ needs.install_godot.outputs.godot-version }}
 
   mono-uint-test:
+    if: ${{ false }}  # disable for now
     strategy:
       fail-fast: false
       matrix:
@@ -106,7 +107,6 @@ jobs:
 
     steps:
       - name: "Checkout"
-        if: ${{ false }}  # disable for now
         if: ${{ !cancelled() }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,60 @@
+name: ci-pr
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.jpg'
+      - '**.png'
+      - '**.md'
+  pull_request_target:
+    paths-ignore:
+      - '**.jpg'
+      - '**.png'
+      - '**.md'
+  workflow_dispatch:
+
+concurrency:
+  group: ci-pr-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  gd-uint-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        godot-version: [3.4.1, 3.4.2, 3.4.4]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: "Install Godot Image"
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/install-godot
+          with:
+            godot-version: ${{ matrix.godot-version }}
+
+      - name: "Checkout"
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@v3
+          with:
+            lfs: true
+            submodules: 'recursive'
+
+      - name: "Unit Test"
+        id: selft-test
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/unit-test
+        with:
+          test-includes: "res://addons/gdUnit3/test/"
+
+      - name: "Publish Unit Test Reports"
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/publish-test-report
+        with:
+          report-name: ${{ matrix.godot-version }}
+
+      - name: "Upload Unit Test Reports"
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/upload-test-report
+        with:
+          report-name: ${{ matrix.godot-version }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -13,6 +13,9 @@ on:
       - '**.md'
   workflow_dispatch:
 
+env:
+  GODOT_BIN: "/usr/local/bin/godot"
+
 concurrency:
   group: ci-pr-${{ github.event.number }}
   cancel-in-progress: true
@@ -38,6 +41,11 @@ jobs:
         with:
           lfs: true
           submodules: 'recursive'
+
+      - name: "Update Project"
+        if: ${{ !cancelled() }}
+        run: |
+          ${{ env.GODOT_BIN }} -e --path project.godot res://addons/gdUnit3/scan_project.tscn --no-window
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}
@@ -65,7 +73,30 @@ jobs:
         with:
           report-name: ${{ matrix.godot-version }}
 
+  compile-mono:
+    steps:
+      - name: "Checkout"
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: 'recursive'
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Compile
+        run: |
+          dotnet restore gdUnit3.csproj
+          mkdir -p .mono/assemblies/Debug
+          cp /usr/local/bin/GodotSharp/Api/Release/* .mono/assemblies/Debug
+          dotnet build -verbosity:m
+
+
   mono-uint-test:
+    needs: compile-mono
     strategy:
       fail-fast: false
       matrix:
@@ -85,17 +116,6 @@ jobs:
         with:
           lfs: true
           submodules: 'recursive'
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 6.0.x
-
-      - name: Compile
-        run: |
-          dotnet restore gdUnit3.csproj
-          mkdir -p .mono/assemblies/Debug
-          cp /usr/local/bin/GodotSharp
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ !cancelled() }}
         timeout-minutes: 1
         run: |
-          ${{ env.GODOT_BIN }} -e --path . res://addons/gdUnit3/scan_project.tscn --no-window --check-only
+          ${{ env.GODOT_BIN }} -e --path . res://addons/gdUnit3/scan_project.tscn --no-window -d --quiet
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -55,7 +55,7 @@ jobs:
         if: ${{ !cancelled() }}
         timeout-minutes: 3
         run: |
-          ${{ steps.install-godot.outputs.path }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window -v
+          ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit3/scan_project.gd --no-window -v
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ !cancelled() }}
         timeout-minutes: 3
         run: |
-          ${{ env.GODOT_BIN }} -e --path . res://addons/gdUnit3/scan_project.tscn --no-window --quiet
+          ${{ env.GODOT_BIN }} -e --path . res://addons/gdUnit3/scan_project.tscn --no-window -v
 
       - name: "Unit Test"
         if: ${{ !cancelled() }}

--- a/addons/gdUnit3/bin/GdUnitCmdTool.gd
+++ b/addons/gdUnit3/bin/GdUnitCmdTool.gd
@@ -27,12 +27,13 @@ class CLIRunner extends Node:
 	var _console := CmdConsole.new()
 	var _cs_executor
 	var _rtf :RichTextLabelExt
-	
 	var _cmd_options: = CmdOptions.new([
 			CmdOption.new("-a, --add", "-a <directory|path of testsuite>", "Adds the given test suite or directory to the execution pipeline.", TYPE_STRING),
 			CmdOption.new("-i, --ignore", "-i <testsuite_name|testsuite_name:test-name>", "Adds the given test suite or test case to the ignore list.", TYPE_STRING),
 			CmdOption.new("-c, --continue", "", "By default GdUnit will abort on first test failure to be fail fast, instead of stop after first failure you can use this option to run the complete test set."),
 			CmdOption.new("-conf, --config", "-conf [testconfiguration.cfg]", "Run all tests by given test configuration. Default is 'GdUnitRunner.cfg'", TYPE_STRING, true),
+			CmdOption.new("-help", "", "Shows this help message."),
+			CmdOption.new("--help-advanced", "", "Shows advanced options.")
 		], [
 			# advanced options
 			CmdOption.new("-rd, --report-directory", "-rd <directory>", "Specifies the output directory in which the reports are to be written. The default is res://reports/.", TYPE_STRING, true),

--- a/addons/gdUnit3/scan_project.gd
+++ b/addons/gdUnit3/scan_project.gd
@@ -1,0 +1,8 @@
+tool
+extends Control
+
+func _ready():
+	print("Scan for project changes ...")
+	yield(get_tree().create_timer(2), "timeout")
+	get_tree().quit(1)
+	prints(" Done")

--- a/addons/gdUnit3/scan_project.gd
+++ b/addons/gdUnit3/scan_project.gd
@@ -27,5 +27,5 @@ func _idle(delta):
 		_state = QUIT
 		prints("Scan for project changes done")
 		yield(root.get_tree(), "idle_frame")
-		quit(0)
+		prints("kill", OS.kill(OS.get_process_id()))
 		yield(root.get_tree(), "idle_frame")

--- a/addons/gdUnit3/scan_project.gd
+++ b/addons/gdUnit3/scan_project.gd
@@ -27,5 +27,6 @@ func _idle(delta):
 		_state = QUIT
 		prints("Scan for project changes done")
 		yield(root.get_tree(), "idle_frame")
-		prints("kill", OS.kill(OS.get_process_id()))
+		finish()
+		#prints("kill", OS.kill(OS.get_process_id()))
 		yield(root.get_tree(), "idle_frame")

--- a/addons/gdUnit3/scan_project.gd
+++ b/addons/gdUnit3/scan_project.gd
@@ -25,5 +25,6 @@ func _idle(delta):
 	if _counter >= WAIT_TIME_IN_MS:
 		prints("Scan for project changes done")
 		_state = QUIT
-		yield(root.get_tree(), "idle_frame")
-		finish()
+		#Engine.get_main_loop().finish()
+		#finish()
+		quit(0)

--- a/addons/gdUnit3/scan_project.gd
+++ b/addons/gdUnit3/scan_project.gd
@@ -1,8 +1,8 @@
-tool
 extends Control
 
 func _ready():
 	print("Scan for project changes ...")
-	yield(get_tree().create_timer(2), "timeout")
+	yield(get_tree().create_timer(30), "timeout")
+	print("Scan for project changes end")
 	get_tree().quit(1)
 	prints(" Done")

--- a/addons/gdUnit3/scan_project.gd
+++ b/addons/gdUnit3/scan_project.gd
@@ -1,19 +1,31 @@
+#!/usr/bin/env -S godot -s
 tool
-extends Control
+extends SceneTree
 
+enum {
+	INIT,
+	SCAN,
+	QUIT
+}
 
 var _counter = 0
 var WAIT_TIME_IN_MS = 5.000
+var _state = INIT
 
-func _ready():
+func _init():
 	print("Scan for project changes ...")
 	prints(OS.get_time())
+	_state = SCAN
 
-func _process(delta):
+func _idle(delta):
+	if _state != SCAN:
+		return
 	_counter += delta
-	prints("scanning", _counter, prints(OS.get_time()))
-	yield(get_tree(), "idle_frame")
+	prints("scanning", _counter, OS.get_time(), OS.get_process_id())
+	yield(root.get_tree(), "idle_frame")
 	if _counter >= WAIT_TIME_IN_MS:
+		_state = QUIT
 		prints("Scan for project changes done")
-		yield(get_tree(), "idle_frame")
-		get_tree().quit(0)
+		yield(root.get_tree(), "idle_frame")
+		quit(0)
+		yield(root.get_tree(), "idle_frame")

--- a/addons/gdUnit3/scan_project.gd
+++ b/addons/gdUnit3/scan_project.gd
@@ -3,15 +3,16 @@ extends Control
 
 
 var _counter = 0
-var WAIT_TIME_IN_MS = 10.000
+var WAIT_TIME_IN_MS = 5.000
 
 func _ready():
 	print("Scan for project changes ...")
+	prints(OS.get_time())
 
 func _process(delta):
 	_counter += delta
 	if _counter >= WAIT_TIME_IN_MS:
-		print("Scan for project changes done")
+		prints("Scan for project changes done")
 		get_tree().quit(1)
-	prints("scanning", _counter)
+	prints("scanning", _counter, prints(OS.get_time()))
 		

--- a/addons/gdUnit3/scan_project.gd
+++ b/addons/gdUnit3/scan_project.gd
@@ -11,8 +11,9 @@ func _ready():
 
 func _process(delta):
 	_counter += delta
+	prints("scanning", _counter, prints(OS.get_time()))
+	yield(get_tree(), "idle_frame")
 	if _counter >= WAIT_TIME_IN_MS:
 		prints("Scan for project changes done")
-		get_tree().quit(1)
-	prints("scanning", _counter, prints(OS.get_time()))
-		
+		yield(get_tree(), "idle_frame")
+		get_tree().quit(0)

--- a/addons/gdUnit3/scan_project.gd
+++ b/addons/gdUnit3/scan_project.gd
@@ -1,13 +1,17 @@
+tool
 extends Control
 
 
 var _counter = 0
+var WAIT_TIME_IN_MS = 10.000
+
+func _ready():
+	print("Scan for project changes ...")
 
 func _process(delta):
-	print("Scan for project changes ...")
-	yield(get_tree().create_timer(1), "timeout")
-	_counter += 1
-	if _counter == 120:
+	_counter += delta
+	if _counter >= WAIT_TIME_IN_MS:
 		print("Scan for project changes done")
 		get_tree().quit(1)
+	prints("scanning", _counter)
 		

--- a/addons/gdUnit3/scan_project.gd
+++ b/addons/gdUnit3/scan_project.gd
@@ -1,8 +1,13 @@
 extends Control
 
-func _ready():
+
+var _counter = 0
+
+func _process(delta):
 	print("Scan for project changes ...")
-	yield(get_tree().create_timer(30), "timeout")
-	print("Scan for project changes end")
-	get_tree().quit(1)
-	prints(" Done")
+	yield(get_tree().create_timer(1), "timeout")
+	_counter += 1
+	if _counter == 120:
+		print("Scan for project changes done")
+		get_tree().quit(1)
+		

--- a/addons/gdUnit3/scan_project.gd
+++ b/addons/gdUnit3/scan_project.gd
@@ -14,19 +14,16 @@ var _state = INIT
 
 func _init():
 	print("Scan for project changes ...")
-	prints(OS.get_time())
 	_state = SCAN
 
 func _idle(delta):
 	if _state != SCAN:
 		return
 	_counter += delta
-	prints("scanning", _counter, OS.get_time(), OS.get_process_id())
+	#prints("scanning", _counter, OS.get_time(), OS.get_process_id())
 	yield(root.get_tree(), "idle_frame")
 	if _counter >= WAIT_TIME_IN_MS:
-		_state = QUIT
 		prints("Scan for project changes done")
+		_state = QUIT
 		yield(root.get_tree(), "idle_frame")
 		finish()
-		#prints("kill", OS.kill(OS.get_process_id()))
-		yield(root.get_tree(), "idle_frame")

--- a/addons/gdUnit3/scan_project.gd
+++ b/addons/gdUnit3/scan_project.gd
@@ -13,6 +13,7 @@ var WAIT_TIME_IN_MS = 5.000
 var _state = INIT
 
 func _init():
+	disable_gdUnit()
 	print("Scan for project changes ...")
 	_state = SCAN
 
@@ -25,6 +26,26 @@ func _idle(delta):
 	if _counter >= WAIT_TIME_IN_MS:
 		prints("Scan for project changes done")
 		_state = QUIT
-		#Engine.get_main_loop().finish()
 		#finish()
-		quit(0)
+		rescan()
+		#Engine.get_main_loop().finish()
+		OS.kill(OS.get_process_id())
+
+
+func rescan(update_scripts :bool = false) -> void:
+	yield(root.get_tree(), "idle_frame")
+	var plugin := EditorPlugin.new()
+	var fs := plugin.get_editor_interface().get_resource_filesystem()
+	fs.scan_sources()
+	while fs.is_scanning():
+		yield(root.get_tree().create_timer(1), "timeout")
+	if update_scripts:
+		plugin.get_editor_interface().get_resource_filesystem().update_script_classes()
+	plugin.free()
+
+
+static func disable_gdUnit() -> void:
+	prints("disable_gdUnit")
+	var plugin := EditorPlugin.new()
+	plugin.get_editor_interface().set_plugin_enabled("gdUnit3", false)
+	plugin.free()

--- a/addons/gdUnit3/scan_project.tscn
+++ b/addons/gdUnit3/scan_project.tscn
@@ -1,9 +1,0 @@
-[gd_scene load_steps=2 format=2]
-
-[ext_resource path="res://addons/gdUnit3/scan_project.gd" type="Script" id=1]
-
-[node name="Node" type="Control"]
-script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}

--- a/addons/gdUnit3/scan_project.tscn
+++ b/addons/gdUnit3/scan_project.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/gdUnit3/scan_project.gd" type="Script" id=1]
+
+[node name="Node" type="Control"]
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/addons/gdUnit3/src/cmd/CmdOptions.gd
+++ b/addons/gdUnit3/src/cmd/CmdOptions.gd
@@ -2,15 +2,13 @@ class_name CmdOptions
 extends Reference
 
 
-var OPTION_HELP = CmdOption.new("-help", "", "Shows this help message.")
-var OPTION_ADVANCES_HELP = CmdOption.new("--help-advanced", "", "Shows advanced options.")
 var _default_options :Array
 var _advanced_options :Array
 
 
 func _init(options :Array = Array(), advanced_options :Array = Array()):
 	# default help options
-	_default_options = [OPTION_HELP, OPTION_ADVANCES_HELP] + options 
+	_default_options = options 
 	_advanced_options = advanced_options
 
 func default_options() -> Array:
@@ -27,6 +25,3 @@ func get_option(cmd :String) -> CmdOption:
 		if Array(option.commands()).has(cmd):
 			return option
 	return null
-
-func is_help(option :CmdOption) -> bool:
-	return option == OPTION_HELP or option == OPTION_ADVANCES_HELP

--- a/addons/gdUnit3/src/ui/parts/InspectorToolBar.gd
+++ b/addons/gdUnit3/src/ui/parts/InspectorToolBar.gd
@@ -5,7 +5,7 @@ signal run_pressed
 signal stop_pressed
 
 
-onready var debug_icon_image :StreamTexture = load("res://addons/gdUnit3/src/ui/assets/PlayDebug.svg")
+onready var debug_icon_image :Texture = load("res://addons/gdUnit3/src/ui/assets/PlayDebug.svg")
 onready var _version_label := $Tools/CenterContainer/version
 onready var _button_wiki := $Tools/help
 onready var _tool_button := $Tools/tool

--- a/addons/gdUnit3/src/update/GdUnitUpdate.gd
+++ b/addons/gdUnit3/src/update/GdUnitUpdate.gd
@@ -23,9 +23,6 @@ var _download_zip_url :String
 var _update_in_progress :bool = false
 
 func _ready():
-	if not Engine.has_meta("enable_update"):
-		prints("disable_update")
-		return
 	_update_button.disabled = true
 	_md_reader.set_http_client(_update_client)
 	request_releases()

--- a/addons/gdUnit3/src/update/GdUnitUpdate.gd
+++ b/addons/gdUnit3/src/update/GdUnitUpdate.gd
@@ -23,6 +23,9 @@ var _download_zip_url :String
 var _update_in_progress :bool = false
 
 func _ready():
+	if not Engine.has_meta("enable_update"):
+		prints("disable_update")
+		return
 	_update_button.disabled = true
 	_md_reader.set_http_client(_update_client)
 	request_releases()
@@ -48,6 +51,7 @@ func _h4_message(message :String, color :Color) -> String:
 
 func _process(_delta):
 	if _show_update:
+		prints("_process update")
 		var spinner := "res://addons/gdUnit3/src/ui/assets/spinner.tres"
 		_content.bbcode_text = _h4_message("\n\n\nRequest release infos ... [img=24x24]%s[/img]" % spinner, Color.snow)
 		popup_centered_ratio(.5)

--- a/addons/gdUnit3/src/update/GdUnitUpdate.gd
+++ b/addons/gdUnit3/src/update/GdUnitUpdate.gd
@@ -48,7 +48,6 @@ func _h4_message(message :String, color :Color) -> String:
 
 func _process(_delta):
 	if _show_update:
-		prints("_process update")
 		var spinner := "res://addons/gdUnit3/src/ui/assets/spinner.tres"
 		_content.bbcode_text = _h4_message("\n\n\nRequest release infos ... [img=24x24]%s[/img]" % spinner, Color.snow)
 		popup_centered_ratio(.5)

--- a/addons/gdUnit3/test/cmd/CmdOptionsTest.gd
+++ b/addons/gdUnit3/test/cmd/CmdOptionsTest.gd
@@ -35,18 +35,9 @@ func test_get_option():
 	# for not existsing command
 	assert_object(_cmd_options.get_option("-z")).is_null()
 
-func test_is_help():
-	assert_bool(_cmd_options.is_help(option_a)).is_false()
-	assert_bool(_cmd_options.is_help(option_b)).is_false()
-	assert_bool(_cmd_options.is_help(option_f)).is_false()
-	assert_bool(_cmd_options.is_help(option_x)).is_false()
-	assert_bool(_cmd_options.is_help(_cmd_options.OPTION_HELP)).is_true()
-	assert_bool(_cmd_options.is_help(_cmd_options.OPTION_ADVANCES_HELP)).is_true()
 
 func test_default_options():
 	assert_array(_cmd_options.default_options()).contains_exactly([
-		_cmd_options.OPTION_HELP,
-		_cmd_options.OPTION_ADVANCES_HELP,
 		option_a, 
 		option_f, 
 		option_b])
@@ -56,8 +47,6 @@ func test_advanced_options():
 
 func test_options():
 	assert_array(_cmd_options.options()).contains_exactly([
-		_cmd_options.OPTION_HELP,
-		_cmd_options.OPTION_ADVANCES_HELP,
 		option_a, 
 		option_f, 
 		option_b,

--- a/default_env.tres
+++ b/default_env.tres
@@ -3,5 +3,4 @@
 [sub_resource type="ProceduralSky" id=1]
 
 [resource]
-background_mode = 2
 background_sky = SubResource( 1 )

--- a/runtest.sh
+++ b/runtest.sh
@@ -6,7 +6,9 @@ if [ -z "$GODOT_BIN" ]; then
     exit 1
 fi
 
-$GODOT_BIN --no-window -s -d ./addons/gdUnit3/bin/GdUnitCmdTool.gd $*
+# we not use no-window because of issue https://github.com/godotengine/godot/issues/55379
+#$GODOT_BIN --no-window -s -d ./addons/gdUnit3/bin/GdUnitCmdTool.gd $*
+$GODOT_BIN -s -d ./addons/gdUnit3/bin/GdUnitCmdTool.gd $*
 exit_code=$?
 $GODOT_BIN --no-window --quiet -s -d ./addons/gdUnit3/bin/GdUnitCopyLog.gd $* > /dev/null
 exit $exit_code


### PR DESCRIPTION
- create ci-pr workflow
- using a matrix to iterate over supported Godot versions
- split existing jobs into separate actions