### PR TITLE
GD-305: Fix client/server request json parsing

### DIFF
--- a/addons/gdUnit3/plugin.cfg
+++ b/addons/gdUnit3/plugin.cfg
@@ -3,5 +3,5 @@
 name="gdUnit3"
 description="Unit Testing Framework for Godot Scripts"
 author="Mike Schulze"
-version="2.2.4"
+version="2.2.5"
 script="plugin.gd"

--- a/addons/gdUnit3/src/network/GdUnitServerConstants.gd
+++ b/addons/gdUnit3/src/network/GdUnitServerConstants.gd
@@ -1,0 +1,6 @@
+class_name GdUnitServerConstants
+extends Reference
+
+const DEFAULT_SERVER_START_RETRY_TIMES = 5
+const GD_TEST_SERVER_PORT :int = 31002
+const JSON_RESPONSE_DELIMITER = "<<JRD>>"

--- a/addons/gdUnit3/src/network/GdUnitTcpClient.gd
+++ b/addons/gdUnit3/src/network/GdUnitTcpClient.gd
@@ -97,7 +97,7 @@ func process_rpc() -> void:
 
 func rpc_send(rpc :RPC) -> void:
 	if _stream != null:
-		var data := "|%s|" % rpc.serialize()
+		var data := GdUnitServerConstants.JSON_RESPONSE_DELIMITER + rpc.serialize() + GdUnitServerConstants.JSON_RESPONSE_DELIMITER
 		_stream.put_data(data.to_ascii())
 
 func rpc_receive() -> RPC:

--- a/addons/gdUnit3/src/network/GdUnitTcpServer.gd
+++ b/addons/gdUnit3/src/network/GdUnitTcpServer.gd
@@ -6,9 +6,6 @@ signal client_connected(client_id)
 signal client_disconnected(client_id)
 signal rpc_data(rpc_data)
 
-const DEFAULT_SERVER_START_RETRY_TIMES = 5
-const GD_TEST_SERVER_PORT :int = 31002
-
 var _server :TCP_Server
 
 class TcpConnection extends Node:
@@ -47,7 +44,7 @@ class TcpConnection extends Node:
 				return
 			else:
 				var data_package :PoolByteArray = data[1]
-				var json_array := data_package.get_string_from_ascii().split("|")
+				var json_array := data_package.get_string_from_ascii().split(GdUnitServerConstants.JSON_RESPONSE_DELIMITER)
 				for json in json_array:
 					# ignore empty jsons
 					if json.empty():
@@ -67,9 +64,9 @@ func _notification(what):
 		stop()
 
 func start() -> Result:
-	var server_port := GD_TEST_SERVER_PORT
+	var server_port := GdUnitServerConstants.GD_TEST_SERVER_PORT
 	var err := OK
-	for retry in DEFAULT_SERVER_START_RETRY_TIMES:
+	for retry in GdUnitServerConstants.DEFAULT_SERVER_START_RETRY_TIMES:
 		err = _server.listen(server_port, "127.0.0.1")
 		if err != OK:
 			prints("GdUnit3: Can't establish server on port %d, error code: %s" % [server_port, err])

--- a/addons/gdUnit3/test/asserts/GdUnitStringAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitStringAssertImplTest.gd
@@ -28,6 +28,9 @@ func test_is_equal():
 		.is_equal("This is a test Message") \
 		.has_failure_message("Expecting:\n 'This is a test Message'\n but was\n 'Null'")
 
+func test_is_equal_pipe_character() -> void:
+	assert_str("AAA|BBB|CCC", GdUnitAssert.EXPECT_FAIL).is_equal("AAA|BBB.CCC")
+
 func test_is_equal_ignoring_case():
 	assert_str("This is a test message").is_equal_ignoring_case("This is a test Message")
 	assert_str("This is a test message", GdUnitAssert.EXPECT_FAIL) \

--- a/project.godot
+++ b/project.godot
@@ -700,6 +700,11 @@ _global_script_classes=[ {
 "path": "res://addons/gdUnit3/test/GdUnitScriptTypeTest.gd"
 }, {
 "base": "Reference",
+"class": "GdUnitServerConstants",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/src/network/GdUnitServerConstants.gd"
+}, {
+"base": "Reference",
 "class": "GdUnitSettings",
 "language": "GDScript",
 "path": "res://addons/gdUnit3/src/core/GdUnitSettings.gd"
@@ -1298,6 +1303,7 @@ _global_script_class_icons={
 "GdUnitSceneRunnerTest": "",
 "GdUnitScriptType": "",
 "GdUnitScriptTypeTest": "",
+"GdUnitServerConstants": "",
 "GdUnitSettings": "",
 "GdUnitSettingsTest": "",
 "GdUnitSignalAssert": "",


### PR DESCRIPTION
- the split of server data packages was broken when data contains a extra pipe character
  use now an dedicated delemiter instead
- bump to version 2.2.5