### PR TITLE
GD-318: rework on assert_signal to collect all emitted signals

### DIFF
--- a/addons/gdUnit3/src/GdUnitSignalAssert.gd
+++ b/addons/gdUnit3/src/GdUnitSignalAssert.gd
@@ -10,6 +10,10 @@ func is_emitted(name :String, args := []) -> GdUnitSignalAssert:
 func is_not_emitted(name :String, args := []) -> GdUnitSignalAssert:
 	return self
 
+# Verifies the signal exists on the emitter
+func is_signal_exists(name :String) -> GdUnitSignalAssert:
+	return self
+
 # Verifies the failure message is equal to expected one.
 func has_failure_message(expected: String) -> GdUnitSignalAssert:
 	return self

--- a/addons/gdUnit3/src/asserts/GdAssertReports.gd
+++ b/addons/gdUnit3/src/asserts/GdAssertReports.gd
@@ -13,6 +13,10 @@ static func report_success(gd_assert :GdUnitAssert) -> GdUnitAssert:
 	gd_assert.send_report(GdUnitReport.new().create(GdUnitReport.SUCCESS, gd_assert._get_line_number(), error_msg))
 	return gd_assert
 
+static func report_warning(gd_assert :GdUnitAssert, message :String, line_number :int) -> GdUnitAssert:
+	gd_assert.send_report(GdUnitReport.new().create(GdUnitReport.WARN, line_number, message))
+	return gd_assert
+
 static func report_error(message:String, gd_assert :GdUnitAssert, line_number :int) -> GdUnitAssert:
 	if gd_assert != null:
 		gd_assert._is_failed = true

--- a/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
@@ -71,7 +71,7 @@ static func _normalize_bbcode(message :String) -> String:
 	var rtl := RichTextLabelExt.new()
 	rtl._ready()
 	rtl.bbcode_enabled = true
-	rtl.parse_bbcode(message)
+	rtl.parse_bbcode(message if message else "")
 	var normalized = rtl.get_text()
 	rtl.free()
 	return normalized

--- a/addons/gdUnit3/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitSignalAssertImpl.gd
@@ -1,12 +1,10 @@
 class_name GdUnitSignalAssertImpl
 extends GdUnitSignalAssert
 
-signal signal_emitted(value)
-
 const DEFAULT_TIMEOUT := 2000
 const NO_ARG = "<--null-->"
 
-var _instance :Object
+var _emitter :Object
 var _current_error_message = null
 var _custom_failure_message = null
 var _line_number := -1
@@ -17,22 +15,123 @@ var _expect_result :int
 var _report_consumer : GdUnitReportConsumer
 var _caller : WeakRef
 var _interrupted := false
+var _signal_collector := SignalCollector.instance()
 
+const _singletons :Dictionary = Dictionary()
+# This is an singelton implementation and reused for each GdUnitSignalAssert
+# It connects to all signals of given emitter and collects received signals and arguments
+# The collected signals are cleand finally when the emitter is freed.
+class SignalCollector:
+	
+	const CLASS_NAME = "SignalCollector"
+	const SIGNAL_BLACK_LIST = []#["tree_exiting", "tree_exited", "child_exiting_tree"]
+	
+	# {
+	#	emitter<Object> : {
+	#		signal_name<String> : [signal_args<Array>],
+	#		...
+	#	}
+	# }
+	var _collected_signals :Dictionary = {}
+	
+	static func instance() -> SignalCollector:
+		if not _singletons.has(CLASS_NAME):
+			_singletons[CLASS_NAME] = SignalCollector.new()
+		return _singletons[CLASS_NAME]
+	
+	# connect to all possible signals defined by the emitter
+	# prepares the signal collection to store received signals and arguments
+	func connect_signals(emitter :Object):
+		if is_instance_valid(emitter):
+			# add new emitter to signal collection
+			if not _collected_signals.has(emitter):
+				_collected_signals[emitter] = Dictionary()
+			# connect to 'tree_exiting' of the emitter to finally release all acquired resources/connections.
+			if !emitter.is_connected("tree_exiting", self, "unregister"):
+				emitter.connect("tree_exiting", self, "unregister", [self, emitter])
+			# connect to all signals of the emitter we want to collect
+			for signal_def in emitter.get_signal_list():
+				var signal_name = signal_def["name"]
+				# set inital collected to empty
+				if not is_signal_collecting(emitter, signal_name):
+					_collected_signals[emitter][signal_name] = Array()
+				if SIGNAL_BLACK_LIST.find(signal_name) != -1:
+					continue
+				if !emitter.is_connected(signal_name, self, "_on_signal_emmited"):
+					emitter.connect(signal_name, self, "_on_signal_emmited", [emitter, signal_name])
+	
+	# unregister all acquired resources/connections, otherwise it ends up in orphans
+	# is called when the emitter is removed from the parent
+	func unregister(receiver :SignalCollector, emitter :Object):
+		if is_instance_valid(receiver):
+			#prints("disconnect_signals", receiver)
+			for connection in receiver.get_incoming_connections():
+				var source :Object = connection["source"]
+				var signal_name :String = connection["signal_name"]
+				var method_name :String = connection["method_name"]
+				#prints("disconnect", signal_name, source, receiver, method_name)
+				source.disconnect(signal_name, receiver, method_name)
+		if is_instance_valid(emitter):
+			_collected_signals.erase(emitter)
+	
+	func _on_signal_emmited( arg0=NO_ARG, arg1=NO_ARG, arg2=NO_ARG, arg3=NO_ARG, arg4=NO_ARG, arg5=NO_ARG, arg6=NO_ARG, arg7=NO_ARG, arg8=NO_ARG, arg9=NO_ARG):
+		var signal_args = GdObjects.array_filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
+		var signal_name :String = signal_args.pop_back()
+		var emitter :Object = signal_args.pop_back()
+		#prints("_on_signal_emmited:", emitter, signal_name, signal_args)
+		_collected_signals[emitter][signal_name].append(signal_args)
+	
+	func reset_received_signals(emitter :Object):
+		#debug_signal_list("before claer");
+		if _collected_signals.has(emitter):
+			for signal_name in _collected_signals[emitter]:
+				_collected_signals[emitter][signal_name].clear()
+		#debug_signal_list("after claer");
+	
+	func is_signal_collecting(emitter :Object, signal_name :String) -> bool:
+		return _collected_signals.has(emitter) and _collected_signals[emitter].has(signal_name)
+	
+	func match(emitter :Object, signal_name :String, args :Array) -> bool:
+		#prints("match", signal_name,  _collected_signals[emitter][signal_name]);
+		for received_args in _collected_signals[emitter][signal_name]:
+			#prints("testing", signal_name, received_args, "vs", args)
+			if GdObjects.equals(received_args, args):
+				return true
+		return false
+	
+	func _debug_signal_list(message :String):
+		prints("-----", message, "-------")
+		prints("senders {")
+		for emitter in _collected_signals:
+			prints("\t", emitter)
+			for signal_name in _collected_signals[emitter]:
+				var args = _collected_signals[emitter][signal_name]
+				prints("\t\t", signal_name, args)
+		prints("}")
 
-func _init(caller :WeakRef, instance :Object, expect_result := EXPECT_SUCCESS):
+func _init(caller :WeakRef, emitter :Object, expect_result := EXPECT_SUCCESS):
 	_line_number = GdUnitAssertImpl._get_line_number()
 	_caller = caller
-	_instance =  instance
+	_emitter =  emitter
 	_expect_result = expect_result
 	GdAssertReports.reset_last_error_line_number()
 	# set report consumer to be use to report the final result
 	_report_consumer = caller.get_ref().get_meta(GdUnitReportConsumer.META_PARAM)
+	_signal_collector.connect_signals(emitter)
 	# we expect the test will fail
 	if expect_result == EXPECT_FAIL:
 		_expect_fail = true
 
+func _notification(what):
+	#prints(GdObjects.notification_as_string(what))
+	if what == NOTIFICATION_PREDELETE:
+		_caller = null
+
 func report_success() -> GdUnitAssert:
 	return GdAssertReports.report_success(self)
+
+func report_warning(message :String) -> GdUnitAssert:
+	return GdAssertReports.report_warning(self, message, GdUnitAssertImpl._get_line_number())
 
 func report_error(error_message :String) -> GdUnitAssert:
 	if _custom_failure_message == null:
@@ -45,7 +144,7 @@ func send_report(report :GdUnitReport)-> void:
 
 # -------- Base Assert wrapping ------------------------------------------------
 func has_failure_message(expected: String) -> GdUnitSignalAssert:
-	var current_error := _extract_plain_message(_current_error_message)
+	var current_error := GdUnitAssertImpl._normalize_bbcode(_current_error_message)
 	if current_error != expected:
 		_expect_fail = false
 		var diffs := GdDiffTool.string_diff(current_error, expected)
@@ -55,7 +154,7 @@ func has_failure_message(expected: String) -> GdUnitSignalAssert:
 	return self
 
 func starts_with_failure_message(expected: String) -> GdUnitSignalAssert:
-	var current_error := _extract_plain_message(_current_error_message)
+	var current_error := GdUnitAssertImpl._normalize_bbcode(_current_error_message)
 	if not current_error.begins_with(expected):
 		_expect_fail = false
 		var diffs := GdDiffTool.string_diff(current_error, expected)
@@ -64,20 +163,13 @@ func starts_with_failure_message(expected: String) -> GdUnitSignalAssert:
 		report_error(GdAssertMessages.error_not_same_error(current, expected))
 	return self
 
-func _extract_plain_message(message) -> String:
-	var rtl := RichTextLabel.new()
-	rtl.bbcode_enabled = true
-	rtl.parse_bbcode(message if message else "")
-	rtl.queue_free()
-	return rtl.get_text()
-
 func override_failure_message(message :String) -> GdUnitSignalAssert:
 	_custom_failure_message = message
 	return self
 
 func wait_until(timeout := 2000) -> GdUnitSignalAssert:
 	if timeout <= 0:
-		push_warning("Invalid timeout param, alloed timeouts must be grater than 0. Use default timeout instead")
+		report_warning("Invalid timeout parameter, allowed timeouts must be greater than 0, use default timeout instead!")
 		_timeout = DEFAULT_TIMEOUT
 	else:
 		_timeout = timeout
@@ -85,27 +177,24 @@ func wait_until(timeout := 2000) -> GdUnitSignalAssert:
 
 # Verifies that given signal is emitted until waiting time
 func is_emitted(name :String, args := []) -> GdUnitSignalAssert:
+	_line_number = GdUnitAssertImpl._get_line_number()
 	return _wail_until_signal(name, args, false)
 
 # Verifies that given signal is NOT emitted until waiting time
 func is_not_emitted(name :String, args := []) -> GdUnitSignalAssert:
+	_line_number = GdUnitAssertImpl._get_line_number()
 	return _wail_until_signal(name, args, true)
 
-func _verify_signal_args(current :Array, expected :Array) -> bool:
-	return  GdObjects.equals(current, expected)
-
 func _wail_until_signal(signal_name :String, expected_args :Array, expect_not_emitted: bool):
-	if _instance == null:
+	if _emitter == null:
 		report_error("Can't wait for signal on a NULL object.")
 		yield(Engine.get_main_loop(), "idle_frame")
 		return self
-	# first verify the signal to wait is defined
-	if not _instance.has_signal(signal_name):
-		report_error("Can't wait for non-existion signal '%s' on object '%s'." % [signal_name,_instance.get_class()])
+	# first verify the signal is defined
+	if not _emitter.has_signal(signal_name):
+		report_error("Can't wait for non-existion signal '%s' on object '%s'." % [signal_name,_emitter.get_class()])
 		yield(Engine.get_main_loop(), "idle_frame")
 		return self
-	# register on signal to wait for
-	_instance.connect(signal_name, self, "_on_signal_emmited")
 	var caller = _caller.get_ref()
 	var time_scale = Engine.get_time_scale()
 	var timeout = Timer.new()
@@ -113,54 +202,20 @@ func _wail_until_signal(signal_name :String, expected_args :Array, expect_not_em
 	timeout.set_one_shot(true)
 	timeout.connect("timeout", self, "_on_timeout")
 	timeout.start((_timeout/1000.0)*time_scale)
-	# sleep timer
-	var sleep := Timer.new()
-	caller.add_child(sleep)
-	sleep.start(0.05)
-	sleep.set_autostart(true)
-	sleep.connect("timeout", self, "_on_sleep_awakening")
 	
 	while not _interrupted:
-		var current_args = yield(self, "signal_emitted")
-		# no signal was catched because of timeout or just sleep interupt
-		if current_args == null:
-			continue
-		var is_signal_emitted = _verify_signal_args(current_args, expected_args)
+		yield(Engine.get_main_loop(), "idle_frame")
+		var is_signal_emitted = _signal_collector.match(_emitter, signal_name, expected_args)
 		if is_signal_emitted:
 			if expect_not_emitted:
-				report_error(GdAssertMessages.error_signal_emitted(signal_name, current_args, LocalTime.elapsed(_timeout-timeout.time_left*1000)))
+				report_error(GdAssertMessages.error_signal_emitted(signal_name, expected_args, LocalTime.elapsed(_timeout-timeout.time_left*1000)))
 			break
 	
 	if _interrupted and not expect_not_emitted:
 		report_error(GdAssertMessages.error_wait_signal(signal_name, expected_args, LocalTime.elapsed(_timeout)))
-		
-	sleep.stop()
-	sleep.queue_free()
-	timeout.queue_free()
-	dispose()
+	timeout.free()
+	_signal_collector.reset_received_signals(_emitter)
 	return self
-
-func _on_signal_emmited(arg0=NO_ARG, arg1=NO_ARG, arg2=NO_ARG, arg3=NO_ARG, arg4=NO_ARG, arg5=NO_ARG, arg6=NO_ARG, arg7=NO_ARG, arg8=NO_ARG, arg9=NO_ARG):
-	var signal_args = GdObjects.array_filter_value([arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9], NO_ARG)
-	call_deferred("emit_signal", "signal_emitted", signal_args)
-
-func _on_sleep_awakening():
-	call_deferred("emit_signal", "signal_emitted", null)
 
 func _on_timeout():
 	_interrupted = true
-	call_deferred("emit_signal", "signal_emitted", null)
-
-# it is important to free all references/connections to prevent orphan nodes
-func dispose():
-	disconnect_connections(self)
-	_caller = null
-
-func disconnect_connections(obj :Object):
-	if is_instance_valid(obj):
-		# disconnect from all connected signals to force freeing, otherwise it ends up in orphans
-		for connection in obj.get_incoming_connections():
-			var source_ :Object = connection["source"]
-			var signal_ :String = connection["signal_name"]
-			var method_name_ :String = connection["method_name"]
-			source_.disconnect(signal_, obj, method_name_)

--- a/addons/gdUnit3/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitSignalAssertImpl.gd
@@ -82,7 +82,8 @@ class SignalCollector:
 		var signal_name :String = signal_args.pop_back()
 		var emitter :Object = signal_args.pop_back()
 		#prints("_on_signal_emmited:", emitter, signal_name, signal_args)
-		_collected_signals[emitter][signal_name].append(signal_args)
+		if is_signal_collecting(emitter, signal_name):
+			_collected_signals[emitter][signal_name].append(signal_args)
 	
 	func reset_received_signals(emitter :Object):
 		#debug_signal_list("before claer");

--- a/addons/gdUnit3/test/asserts/GdUnitSignalAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitSignalAssertImplTest.gd
@@ -104,8 +104,6 @@ func test_is_signal_exists() -> void:
 		.is_signal_exists("visibility_changed")\
 		.is_signal_exists("tree_entered")\
 		.is_signal_exists("tree_exiting")\
-		.is_signal_exists("child_entered_tree")\
-		.is_signal_exists("child_exiting_tree")\
 		.is_signal_exists("tree_exited")
 	
 	assert_signal(node, GdUnitAssert.EXPECT_FAIL).is_signal_exists("not_existing_signal")\

--- a/addons/gdUnit3/test/asserts/GdUnitSignalAssertImplTest.gd
+++ b/addons/gdUnit3/test/asserts/GdUnitSignalAssertImplTest.gd
@@ -95,3 +95,18 @@ func test_node_changed_emitting_signals():
 	
 	node.show()
 	yield(assert_signal(node).wait_until(200).is_emitted("draw"), "completed")
+
+func test_is_signal_exists() -> void:
+	var node :Node2D = auto_free(Node2D.new())
+	
+	assert_signal(node).is_signal_exists("visibility_changed")\
+		.is_signal_exists("draw")\
+		.is_signal_exists("visibility_changed")\
+		.is_signal_exists("tree_entered")\
+		.is_signal_exists("tree_exiting")\
+		.is_signal_exists("child_entered_tree")\
+		.is_signal_exists("child_exiting_tree")\
+		.is_signal_exists("tree_exited")
+	
+	assert_signal(node, GdUnitAssert.EXPECT_FAIL).is_signal_exists("not_existing_signal")\
+		.has_failure_message("The signal 'not_existing_signal' not exists on object 'Node2D'.")


### PR DESCRIPTION
- assert_signal was not collection all emitted signal when using multiple times on the same emitter
- refacore the signal collector to use an singleton to collect all signals over the emitter live time