### PR TITLE
GD-322: Encloses the error message when writing a JUnit XML report in a CDATA block

### DIFF
--- a/addons/gdUnit3/src/report/XmlElement.gd
+++ b/addons/gdUnit3/src/report/XmlElement.gd
@@ -52,4 +52,7 @@ func to_xml() -> String:
 			"attributes": attributes, 
 			"childs": childs, 
 			"_indentation": _indentation(),
-			"text": _text})
+			"text": cdata(_text)})
+
+func cdata(text :String) -> String:
+	return "" if text.empty() else "<![CDATA[\n{text}]]>\n".format({"text" : text})

--- a/addons/gdUnit3/test/report/XmlElementTest.gd
+++ b/addons/gdUnit3/test/report/XmlElementTest.gd
@@ -71,7 +71,9 @@ func test_add_text() -> void:
 		.text("This is a message")
 	var expected = \
 """<testsuites>
+<![CDATA[
 This is a message
+]]>
 </testsuites>
 """.replace("\r", "")
 	assert_str(element.to_xml()).is_equal(expected)
@@ -126,8 +128,10 @@ func test_complex_example() -> void:
 		</testcase>
 		<testcase id="2" name="test_case_2">
 			<failure message="test_case.gd:12" type="FAILURE">
+<![CDATA[
 This is a failure
 Expecting true but was false
+]]>
 			</failure>
 		</testcase>
 		<testcase id="3" name="test_case_3">


### PR DESCRIPTION
- a failure message was writen plain in the XML and resulting in a invalid XML
- fixed by enclose the message in a CDATA block