### PR TITLE
Introduce 'test_case_names()' on test case to build the test case names from given parameter set

### DIFF
--- a/addons/gdUnit3/src/core/_TestCase.gd
+++ b/addons/gdUnit3/src/core/_TestCase.gd
@@ -143,5 +143,12 @@ func set_test_parameters(test_parameters :Array) -> void:
 func test_parameters() -> Array:
 	return _test_parameters
 
+func test_case_names() -> PoolStringArray:
+	var test_case_names :=  PoolStringArray()
+	var test_name = get_name()
+	for input_values in _test_parameters:
+		test_case_names.append("%s %s" % [test_name, str(input_values)])
+	return test_case_names
+
 func _to_string():
 	return "%s :%d (%dms)" % [get_name(), _line_number, _timeout]

--- a/addons/gdUnit3/src/network/rpc/dtos/GdUnitTestCaseDto.gd
+++ b/addons/gdUnit3/src/network/rpc/dtos/GdUnitTestCaseDto.gd
@@ -2,7 +2,7 @@ class_name GdUnitTestCaseDto
 extends GdUnitResourceDto
 
 var _line_number :int = -1
-var _test_parameters :Array = []
+var _test_case_names :PoolStringArray = []
 
 func serialize(test_case) -> Dictionary:
 	var serialized := .serialize(test_case)
@@ -10,18 +10,18 @@ func serialize(test_case) -> Dictionary:
 		serialized["line_number"] = test_case.line_number()
 	else:
 		serialized["line_number"] = test_case.get("LineNumber")
-	if test_case.has_method("test_parameters"):
-		serialized["test_parameters"] = test_case.test_parameters()
+	if test_case.has_method("test_case_names"):
+		serialized["test_case_names"] = test_case.test_case_names()
 	return serialized
 
 func deserialize(data :Dictionary) -> GdUnitResourceDto:
 	.deserialize(data)
 	_line_number = data.get("line_number", -1)
-	_test_parameters = data.get("test_parameters", [])
+	_test_case_names = data.get("test_case_names", [])
 	return self
 
 func line_number() -> int:
 	return _line_number
 
-func test_parameters() -> Array:
-	return _test_parameters
+func test_case_names() -> PoolStringArray:
+	return _test_case_names

--- a/addons/gdUnit3/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit3/src/ui/parts/InspectorTreeMainPanel.gd
@@ -421,26 +421,25 @@ func add_test(parent :TreeItem, test_case :GdUnitTestCaseDto) -> void:
 	item.set_meta(META_LINE_NUMBER, test_case.line_number())
 	add_tree_item_to_cache(parent.get_meta(META_RESOURCE_PATH), test_name, item)
 	
-	var value_set = test_case.test_parameters()
-	if not value_set.empty():
-		item.set_meta(META_GDUNIT_TOTAL_TESTS, value_set.size())
+	var test_case_names := test_case.test_case_names()
+	if not test_case_names.empty():
+		item.set_meta(META_GDUNIT_TOTAL_TESTS, test_case_names.size())
 		item.set_meta(META_GDUNIT_SUCCESS_TESTS, 0)
 		_update_item_counter(item)
-		add_test_cases(item, test_name, value_set)
+		add_test_cases(item, test_case_names)
 
-func add_test_cases(parent :TreeItem, test_name :String, value_set :Array) -> void:
-	for index in value_set.size():
-		var input_values :Array = value_set[index]
+func add_test_cases(parent :TreeItem, test_case_names :Array) -> void:
+	for index in test_case_names.size():
+		var test_case_name = test_case_names[index]
 		var item := _tree.create_item(parent)
-		var name = "%s %s" % [test_name, str(input_values)]
-		item.set_text(0, name)
+		item.set_text(0, test_case_name)
 		item.set_icon(0, ICON_TEST_DEFAULT)
 		item.set_meta(META_GDUNIT_STATE, STATE.INITIAL)
-		item.set_meta(META_GDUNIT_NAME, name)
+		item.set_meta(META_GDUNIT_NAME, test_case_name)
 		item.set_meta(META_GDUNIT_TYPE, GdUnitType.TEST_CASE)
 		item.set_meta(META_RESOURCE_PATH, parent.get_meta(META_RESOURCE_PATH))
 		item.set_meta(META_LINE_NUMBER, parent.get_meta(META_LINE_NUMBER))
-		add_tree_item_to_cache(parent.get_meta(META_RESOURCE_PATH), name, item)
+		add_tree_item_to_cache(parent.get_meta(META_RESOURCE_PATH), test_case_name, item)
 
 ################################################################################
 # Tree signal receiver

--- a/addons/gdUnit3/test/GdUnitTestResourceLoaderTest.gd
+++ b/addons/gdUnit3/test/GdUnitTestResourceLoaderTest.gd
@@ -1,0 +1,14 @@
+# GdUnit generated TestSuite
+#warning-ignore-all:unused_argument
+#warning-ignore-all:return_value_discarded
+class_name GdUnitTestResourceLoaderTest
+extends GdUnitTestSuite
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit3/test/GdUnitTestResourceLoader.gd'
+
+func test_load_test_suite_gd() -> void:
+	var resource_path = "res://addons/gdUnit3/test/core/resources/testsuites/TestSuiteParameterizedTests.resource"
+	var test_suite := GdUnitTestResourceLoader.load_test_suite_gd(resource_path)
+	assert_that(test_suite).is_not_null()
+	test_suite.free()

--- a/addons/gdUnit3/test/core/TestSuiteScannerTest.gd
+++ b/addons/gdUnit3/test/core/TestSuiteScannerTest.gd
@@ -323,16 +323,17 @@ func test_is_script_format_supported() -> void:
 	assert_bool(_TestSuiteScanner._is_script_format_supported("res://exampe.tres")).is_false()
 
 func test_load_parameterized_test_suite():
-	var test_suite :GdUnitTestSuite = auto_free(GdUnitTestResourceLoader.load_test_suite("res://addons/gdUnit3/test/core/resources/testsuites/ParameterizedTestSuite.resource"))
+	var test_suite :GdUnitTestSuite = auto_free(GdUnitTestResourceLoader.load_test_suite("res://addons/gdUnit3/test/core/resources/testsuites/TestSuiteInvalidParameterizedTests.resource"))
 	
-	assert_that(test_suite.name).is_equal("ParameterizedTestSuite")
-	assert_that(test_suite.get_script().get_path()).is_equal("res://addons/gdUnit3/test/core/resources/testsuites/ParameterizedTestSuite.resource")
-	assert_that(test_suite.get_children()).extract("get_name")\
-		.contains_exactly_in_any_order(["test_no_parameters",
-				"test_parameterized_success",
-				"test_parameterized_failed",
-				"test_parameterized_to_less_args",
-				"test_parameterized_to_many_args",
-				"test_parameterized_to_less_args_at_index_1",
-				"test_parameterized_invalid_struct",
-				"test_parameterized_invalid_args"])
+	assert_that(test_suite.name).is_equal("TestSuiteInvalidParameterizedTests")
+	assert_that(test_suite.get_script().get_path()).is_equal("res://addons/gdUnit3/test/core/resources/testsuites/TestSuiteInvalidParameterizedTests.resource")
+	assert_that(test_suite.get_children()).extractv(extr("get_name"), extr("is_skipped"))\
+		.contains_exactly_in_any_order([
+			tuple("test_no_parameters", false),
+			tuple("test_parameterized_success", false),
+			tuple("test_parameterized_failed", false),
+			tuple("test_parameterized_to_less_args", true),
+			tuple("test_parameterized_to_many_args", true),
+			tuple("test_parameterized_to_less_args_at_index_1", true),
+			tuple("test_parameterized_invalid_struct", true),
+			tuple("test_parameterized_invalid_args", true)])

--- a/addons/gdUnit3/test/core/resources/testsuites/TestSuiteInvalidParameterizedTests.resource
+++ b/addons/gdUnit3/test/core/resources/testsuites/TestSuiteInvalidParameterizedTests.resource
@@ -1,4 +1,4 @@
-class_name ParameterizedTestSuite
+class_name TestSuiteInvalidParameterizedTests
 extends GdUnitTestSuite
 
 func test_no_parameters():
@@ -8,14 +8,14 @@ func test_parameterized_success(a: int, b :int, c :int, expected :int, test_para
 	[1, 2, 3, 6],
 	[3, 4, 5, 12],
 	[6, 7, 8, 21] ]):
-	
+
 	assert_that(a+b+c).is_equal(expected)
 
 func test_parameterized_failed(a: int, b :int, c :int, expected :int, test_parameters := [
 	[1, 2, 3, 6],
 	[3, 4, 5, 11],
 	[6, 7, 8, 21] ]):
-	
+
 	assert_that(a+b+c).is_equal(expected)
 
 func test_parameterized_to_less_args(a: int, b :int, expected :int, test_parameters := [

--- a/addons/gdUnit3/test/core/resources/testsuites/TestSuiteParameterizedTests.resource
+++ b/addons/gdUnit3/test/core/resources/testsuites/TestSuiteParameterizedTests.resource
@@ -1,0 +1,66 @@
+#warning-ignore-all:unused_argument
+class_name TestSuiteParameterizedTests
+extends GdUnitTestSuite
+
+
+func test_parameterized_bool_value(a: int, expected :bool, test_parameters := [
+	[0, false],
+	[1, true]]):
+
+	assert_that(bool(a)).is_equal(expected)
+
+func test_parameterized_int_values(a: int, b :int, c :int, expected :int, test_parameters := [
+	[1, 2, 3, 6],
+	[3, 4, 5, 12],
+	[6, 7, 8, 21] ]):
+
+	assert_that(a+b+c).is_equal(expected)
+
+func test_parameterized_int_values_fail(a: int, b :int, c :int, expected :int, test_parameters := [
+	[1, 2, 3, 6],
+	[3, 4, 5, 11],
+	[6, 7, 8, 22] ]):
+
+	assert_that(a+b+c).is_equal(expected)
+
+func test_parameterized_float_values(a: float, b :float, expected :float, test_parameters := [
+	[2.2, 2.2, 4.4],
+	[2.2, 2.3, 4.5],
+	[3.3, 2.2, 5.5] ]):
+
+	assert_float(a+b).is_equal(expected)
+
+func test_parameterized_string_values(a: String, b :String, expected :String, test_parameters := [
+	["2.2", "2.2", "2.22.2"],
+	["foo", "bar", "foobar"],
+	["a", "b", "ab"] ]):
+
+	assert_that(a+b).is_equal(expected)
+
+func test_parameterized_Vector2_values(a: Vector2, b :Vector2, expected :Vector2, test_parameters := [
+	[Vector2.ONE, Vector2.ONE, Vector2(2, 2)],
+	[Vector2.LEFT, Vector2.RIGHT, Vector2.ZERO],
+	[Vector2.ZERO, Vector2.LEFT, Vector2.LEFT] ]):
+
+	assert_that(a+b).is_equal(expected)
+
+func test_parameterized_Vector3_values(a: Vector3, b :Vector3, expected :Vector3, test_parameters := [
+	[Vector3.ONE, Vector3.ONE, Vector3(2, 2, 2)],
+	[Vector3.LEFT, Vector3.RIGHT, Vector3.ZERO],
+	[Vector3.ZERO, Vector3.LEFT, Vector3.LEFT] ]):
+
+	assert_that(a+b).is_equal(expected)
+
+class TestObj extends Reference:
+	var _value :String
+
+	func _init(value :String):
+		_value = value
+
+	func _to_string() -> String:
+		return _value
+
+func test_parameterized_obj_values(a: Object, b :Object, expected :String, test_parameters := [
+	[TestObj.new("abc"), TestObj.new("def"), "abcdef"]]):
+
+	assert_that(a.to_string()+b.to_string()).is_equal(expected)

--- a/project.godot
+++ b/project.godot
@@ -844,6 +844,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gdUnit3/test/GdUnitTestResourceLoader.gd"
 }, {
+"base": "GdUnitTestSuite",
+"class": "GdUnitTestResourceLoaderTest",
+"language": "GDScript",
+"path": "res://addons/gdUnit3/test/GdUnitTestResourceLoaderTest.gd"
+}, {
 "base": "Node",
 "class": "GdUnitTestSuite",
 "language": "GDScript",
@@ -1367,6 +1372,7 @@ _global_script_class_icons={
 "GdUnitTestCaseDto": "",
 "GdUnitTestCaseReport": "",
 "GdUnitTestResourceLoader": "",
+"GdUnitTestResourceLoaderTest": "",
 "GdUnitTestSuite": "",
 "GdUnitTestSuiteBuilder": "",
 "GdUnitTestSuiteBuilderTest": "",


### PR DESCRIPTION
- moved the test case name building from UI to backend to be compatible with the c# test case name building
- fix GdUnitTestResourceLoader.gd bug on loading resource containing inner classes
- add executor test for parameterized tests