### PR TITLE
GD-327: Fix 'Unicode error: invalid skip' on plugin startup

### DIFF
--- a/addons/gdUnit3/src/core/GdUnitRunnerConfig.gd
+++ b/addons/gdUnit3/src/core/GdUnitRunnerConfig.gd
@@ -92,7 +92,7 @@ func save(path :String = CONFIG_FILE) -> Result:
 	if err != OK:
 		return Result.error("Can't write test runner configuration '%s'! %s" % [path, GdUnitTools.error_as_string(err)])
 	_config[VERSION] = CONFIG_VERSION
-	file.store_var(_config)
+	file.store_string(to_json(_config))
 	file.close()
 	return Result.success(path)
 


### PR DESCRIPTION
- the error was shown since i switch to JSON format for config file on the c# explorer
- to fix we now write/read consistent in JSON format for Godot and VSC plugin