### PR TITLE
GD-337: Allow to run a single parameterized test from the inspector

### DIFF
--- a/addons/gdUnit3/src/core/GdUnitExecutor.gd
+++ b/addons/gdUnit3/src/core/GdUnitExecutor.gd
@@ -274,8 +274,12 @@ func execute_test_case_parameterized(test_suite :GdUnitTestSuite, test_case :_Te
 	var current_failed_count = _total_test_failed
 	var current_warning_count =_total_test_warnings
 	var test_case_parameters := test_case.test_parameters()
+	var test_parameter_index := test_case.test_parameter_index()
 	var test_case_names := test_case.test_case_names()
 	for test_case_index in test_case.test_parameters().size():
+		# is test_parameter_index is set, we run this parameterized test only
+		if test_parameter_index != -1 and test_parameter_index != test_case_index:
+			continue
 		var fs = test_before(test_suite, test_case, test_case_names[test_case_index])
 		if GdUnitTools.is_yielded(fs):
 			yield(fs, "completed")

--- a/addons/gdUnit3/src/core/GdUnitRunner.gd
+++ b/addons/gdUnit3/src/core/GdUnitRunner.gd
@@ -111,14 +111,27 @@ func gdUnitInit() -> void:
 	for test_suite in _test_suites_to_process:
 		send_test_suite(test_suite)
 
-func _filter_test_case(test_suites :Array, includes_tests :Array) -> void:
-	if includes_tests.empty():
+func _filter_test_case(test_suites :Array, included_tests :Array) -> void:
+	if included_tests.empty():
 		return
 	for test_suite in test_suites:
 		for test_case in test_suite.get_children():
-			if not includes_tests.has(test_case.get_name()):
-				test_suite.remove_child(test_case)
-				test_case.free()
+			_do_filter_test_case(test_suite, test_case, included_tests)
+
+func _do_filter_test_case(test_suite :Node, test_case :Node, included_tests :Array) -> void:
+	for included_test in included_tests:
+		var test_meta :PoolStringArray = included_test.split(":")
+		var test_name := test_meta[0]
+		if test_case.get_name() == test_name:
+			# we have a paremeterized test selection
+			if test_meta.size() > 1:
+				var test_param_index := test_meta[1]
+				test_case.set_test_parameter_index(test_param_index.to_int())
+			return
+	# the test is filtered out
+	test_suite.remove_child(test_case)
+	test_case.free()
+
 
 func _collect_test_case_count(testSuites :Array) -> int:
 	var total :int = 0

--- a/addons/gdUnit3/src/core/GdUnitRunnerConfig.gd
+++ b/addons/gdUnit3/src/core/GdUnitRunnerConfig.gd
@@ -47,10 +47,13 @@ func add_test_suites(resource_paths :PoolStringArray) -> GdUnitRunnerConfig:
 		add_test_suite(resource_path)
 	return self
 
-func add_test_case(resource_path :String, test_name :String) -> GdUnitRunnerConfig:
+func add_test_case(resource_path :String, test_name :String, test_param_index :int = -1) -> GdUnitRunnerConfig:
 	var to_execute := to_execute()
 	var test_cases :Array = to_execute.get(resource_path, Array())
-	test_cases.append(test_name)
+	if test_param_index != -1:
+		test_cases.append("%s:%d" % [test_name, test_param_index])
+	else:
+		test_cases.append(test_name)
 	to_execute[resource_path] = test_cases
 	return self
 

--- a/addons/gdUnit3/src/core/_TestCase.gd
+++ b/addons/gdUnit3/src/core/_TestCase.gd
@@ -9,6 +9,7 @@ var _iterations: int = 1
 var _seed: int
 var _fuzzers: PoolStringArray = PoolStringArray()
 var _test_parameters := Array()
+var _test_param_index := -1
 var _line_number: int = -1
 var _script_path: String
 var _skipped := false
@@ -140,8 +141,14 @@ func skip(skipped :bool, error :String = "") -> void:
 func set_test_parameters(test_parameters :Array) -> void:
 	_test_parameters = test_parameters
 
+func set_test_parameter_index(index :int) -> void:
+	_test_param_index = index
+
 func test_parameters() -> Array:
 	return _test_parameters
+
+func test_parameter_index() -> int:
+	return _test_param_index
 
 func test_case_names() -> PoolStringArray:
 	var test_case_names :=  PoolStringArray()

--- a/addons/gdUnit3/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit3/src/ui/GdUnitInspector.gd
@@ -231,7 +231,7 @@ func _on_fscript_editor_context_menu_pressed(id :int, text_edit :TextEdit):
 	if result:
 		var func_name := result.get_string(2).strip_edges()
 		if func_name.begins_with("test_"):
-			run_test_case(current_script.resource_path, func_name, debug)
+			run_test_case(current_script.resource_path, func_name, -1, debug)
 			return
 
 	# otherwise run the full test suite
@@ -250,11 +250,11 @@ func run_test_suites(test_suite_paths :Array, debug :bool, rerun :bool=false) ->
 			return
 	_gdUnit_run(debug)
 
-func run_test_case(test_suite_resource_path :String, test_case :String, debug :bool, rerun :bool=false) -> void:
+func run_test_case(test_suite_resource_path :String, test_case :String, test_param_index :int, debug :bool, rerun :bool=false) -> void:
 	# create new runner config for fresh run otherwise use saved one
 	if not rerun:
 		var result := _runner_config.clear()\
-			.add_test_case(test_suite_resource_path, test_case)\
+			.add_test_case(test_suite_resource_path, test_case, test_param_index)\
 			.save()
 		if result.is_error():
 			push_error(result.error_message())
@@ -374,8 +374,8 @@ func _on_ToolBar_stop_pressed():
 func _on_MainPanel_run_testsuite(test_suite_paths :Array, debug :bool):
 	run_test_suites(test_suite_paths, debug)
 
-func _on_MainPanel_run_testcase(resource_path :String, test_case :String, debug :bool):
-	run_test_case(resource_path, test_case, debug)
+func _on_MainPanel_run_testcase(resource_path :String, test_case :String, test_param_index :int, debug :bool):
+	run_test_case(resource_path, test_case, test_param_index, debug)
 
 ##########################################################################
 # Network stuff

--- a/addons/gdUnit3/src/ui/parts/InspectorTreeMainPanel.gd
+++ b/addons/gdUnit3/src/ui/parts/InspectorTreeMainPanel.gd
@@ -1,7 +1,7 @@
 tool
 extends VSplitContainer
 
-signal run_testcase
+signal run_testcase(test_suite_resource_path, test_case, test_param_index, run_debug)
 signal run_testsuite
 
 
@@ -50,6 +50,7 @@ const META_GDUNIT_REPORT := "gdUnit_report"
 const META_GDUNIT_ORPHAN := "gdUnit_orphan"
 const META_RESOURCE_PATH := "resource_path"
 const META_LINE_NUMBER := "line_number"
+const META_TEST_PARAM_INDEX := "test_param_index"
 
 var _editor :EditorPlugin
 var _tree_root :TreeItem
@@ -419,6 +420,7 @@ func add_test(parent :TreeItem, test_case :GdUnitTestCaseDto) -> void:
 	item.set_meta(META_GDUNIT_TYPE, GdUnitType.TEST_CASE)
 	item.set_meta(META_RESOURCE_PATH, parent.get_meta(META_RESOURCE_PATH))
 	item.set_meta(META_LINE_NUMBER, test_case.line_number())
+	item.set_meta(META_TEST_PARAM_INDEX, -1)
 	add_tree_item_to_cache(parent.get_meta(META_RESOURCE_PATH), test_name, item)
 	
 	var test_case_names := test_case.test_case_names()
@@ -439,6 +441,7 @@ func add_test_cases(parent :TreeItem, test_case_names :Array) -> void:
 		item.set_meta(META_GDUNIT_TYPE, GdUnitType.TEST_CASE)
 		item.set_meta(META_RESOURCE_PATH, parent.get_meta(META_RESOURCE_PATH))
 		item.set_meta(META_LINE_NUMBER, parent.get_meta(META_LINE_NUMBER))
+		item.set_meta(META_TEST_PARAM_INDEX, index)
 		add_tree_item_to_cache(parent.get_meta(META_RESOURCE_PATH), test_case_name, item)
 
 ################################################################################
@@ -457,8 +460,12 @@ func _on_run_pressed(run_debug :bool) -> void:
 		return
 	var parent = item.get_parent()
 	var test_suite_resource_path = parent.get_meta(META_RESOURCE_PATH)
-	var test_case = item.get_text(0)
-	emit_signal("run_testcase", test_suite_resource_path, test_case, run_debug)
+	var test_case = item.get_meta(META_GDUNIT_NAME)
+	# handle parameterized test selection
+	var test_param_index = item.get_meta(META_TEST_PARAM_INDEX)
+	if test_param_index != -1:
+		test_case = parent.get_meta(META_GDUNIT_NAME)
+	emit_signal("run_testcase", test_suite_resource_path, test_case, test_param_index, run_debug)
 
 func _on_Tree_item_selected() -> void:
 	# only show report on manual item selection


### PR DESCRIPTION
# Why
By default, you can execute only one selected test or test suite. For parameterized tests, the inspector is populated with all parameterized tests when the test is executed. If a test fails, you have to re-run the entire test case, but it would be nice if you could select one of the parameterized test runs and re-run it as a single case.

![image](https://user-images.githubusercontent.com/347037/208474744-c29e65a6-74cf-43dd-883b-d9cf0cd0eb58.png)


# What
Implemented to run a selected parameterized test case via the inspector context menu.

![image](https://user-images.githubusercontent.com/347037/208474980-482b9954-81eb-4702-8e82-7974027f8811.png)
