### PR TITLE
GD-336: Improve test suite parsing for large function descriptors

### DIFF
--- a/addons/gdUnit3/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit3/src/core/parse/GdScriptParser.gd
@@ -642,22 +642,12 @@ func is_static_func(func_signature :String) -> bool:
 func is_inner_class(clazz_path :PoolStringArray) -> bool:
 	return clazz_path.size() > 1
 
+
 func is_func_end(row :String) -> bool:
-	var input := clean_up_row(row)
-	var current_index = 0
-	var token :Token = null
-	while current_index < len(input):
-		# function ends without return type definition
-		if TOKEN_FUNCTION_END.match(input, current_index):
-			return true
-		# function ends with return type definition
-		if TOKEN_FUNCTION_RETURN_TYPE.match(input, current_index):
-			return true
-		token = next_token(input, current_index) as Token
-		if token == TOKEN_NOT_MATCH:
-			return false
-		current_index += token._consumed
+	if row.strip_edges(false, true).ends_with(":"):
+		return true
 	return false
+
 
 func _patch_inner_class_names(value :String, clazz_name :String) -> String:
 	var patch := value

--- a/addons/gdUnit3/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit3/src/core/parse/GdScriptParser.gd
@@ -522,10 +522,9 @@ func extract_source_code(script_path :PoolStringArray) -> PoolStringArray:
 func extract_func_signature(rows :PoolStringArray, index :int) -> String:
 	var signature = ""
 	for rowIndex in range(index, rows.size()):
-		var row :String = rows[rowIndex]
-		signature += row.trim_prefix("\t").trim_suffix("\t")
+		signature += rows[rowIndex].strip_edges()
 		if is_func_end(signature):
-			return clean_up_row(signature).replace("\n", "")
+			return clean_up_row(signature)
 	push_error("Can't fully extract function signature of '%s'" % rows[index])
 	return ""
 
@@ -644,9 +643,7 @@ func is_inner_class(clazz_path :PoolStringArray) -> bool:
 
 
 func is_func_end(row :String) -> bool:
-	if row.strip_edges(false, true).ends_with(":"):
-		return true
-	return false
+	return row.strip_edges(false, true).ends_with(":")
 
 
 func _patch_inner_class_names(value :String, clazz_name :String) -> String:

--- a/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
@@ -439,6 +439,7 @@ func test_is_func_end() -> void:
 	assert_bool(_parser.is_func_end("		):")).is_true()
 	assert_bool(_parser.is_func_end("	-> void:")).is_true()
 	assert_bool(_parser.is_func_end("		) -> void :")).is_true()
+	assert_bool(_parser.is_func_end("func test_a(arg1, arg2 = {1:2} ):")).is_true()
 
 func test_extract_func_signature_multiline() -> void:
 	var source_code = [


### PR DESCRIPTION
# Why
Loading of a test suite with an parameterized test and a huge parameter set was resulting in extrem long loading time


# What
Simplifyed the function descriptor parsing to speedup loading time.