### PR TITLE
GD-341: Using a dictionary parameter in parameterized tests results into a runtime error

### DIFF
--- a/addons/gdUnit3/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit3/src/core/parse/GdScriptParser.gd
@@ -328,25 +328,10 @@ func parse_func_return_type(row: String) -> int:
 
 func parse_return_token(row: String) -> Token:
 	var input := clean_up_row(row)
-	var current_index := 0
-	var token :Token = null
-	var bracket := 0
-	while current_index < len(input):
-		token = next_token(input, current_index) as Token
-		current_index += token._consumed
-		if token == TOKEN_BRACKET_OPEN:
-			bracket += 1
-		if token == TOKEN_BRACKET_CLOSE:
-			bracket -= 1
-		# function end reached ?
-		if bracket == 0 and token == TOKEN_BRACKET_CLOSE:
-			token = next_token(input, current_index) as Token
-			current_index += token._consumed
-			if token == TOKEN_FUNCTION_RETURN_TYPE:
-				return next_token(input, current_index) as Token
-			else:
-				return TOKEN_NOT_MATCH
-	return TOKEN_NOT_MATCH
+	var index := input.find_last(TOKEN_FUNCTION_RETURN_TYPE._token)
+	if index == -1:
+		return TOKEN_NOT_MATCH
+	return next_token(input, index + TOKEN_FUNCTION_RETURN_TYPE._consumed)
 
 # Parses the argument into a argument signature
 # e.g. func foo(arg1 :int, arg2 = 20) -> [arg1, arg2]

--- a/addons/gdUnit3/test/core/ParameterizedTestCaseTest.gd
+++ b/addons/gdUnit3/test/core/ParameterizedTestCaseTest.gd
@@ -35,6 +35,10 @@ var _expected_tests = {
 	],
 	"test_parameterized_obj_values" : [
 		[TestObj.new("abc"), TestObj.new("def"), "abcdef"]
+	],
+	"test_parameterized_dict_values" : [
+		[{"key_a":"value_a"}, "{key_a:value_a}"], 
+		[{"key_b":"value_b"}, "{key_b:value_b}"]
 	]
 }
 
@@ -116,3 +120,11 @@ func test_parameterized_obj_values(a: Object, b :Object, expected :String, test_
 	collect_test_call("test_parameterized_obj_values", [a, b, expected])
 	assert_that(a.to_string()+b.to_string()).is_equal(expected)
 
+
+func test_parameterized_dict_values(data: Dictionary, expected :String, test_parameters := [
+	[{"key_a" : "value_a"}, "{key_a:value_a}"],
+	[{"key_b" : "value_b"}, "{key_b:value_b}"]
+	]):
+	
+	collect_test_call("test_parameterized_dict_values", [data, expected])
+	assert_that(str(data)).is_equal(expected)

--- a/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
@@ -269,6 +269,9 @@ func test_parse_function_return_type():
 	assert_that(_parser.parse_func_return_type("func foo() -> PoolVector2Array:")).is_equal(TYPE_VECTOR2_ARRAY)
 	assert_that(_parser.parse_func_return_type("func foo() -> PoolVector3Array:")).is_equal(TYPE_VECTOR3_ARRAY)
 	assert_that(_parser.parse_func_return_type("func foo() -> PoolColorArray:")).is_equal(TYPE_COLOR_ARRAY)
+	# test with complex function signature
+	var signature := 'functest_parameterized_dict_values(data:Dictionary,expected:String,test_parameters:=[[{"key_a":"value_a"},"key_a:value_a"],[{"key_b":"value_b"},"key_b:value_b"]]):'
+	assert_that(_parser.parse_func_return_type(signature)).is_equal(TYPE_NIL)
 
 func test_parse_func_name():
 	assert_str(_parser.parse_func_name("func foo():")).is_equal("foo")


### PR DESCRIPTION
# Why
Using dictionary on a parameterized was end up into a runtime error.

# What
Fix the script parser to work with dictionaries as test arguments