### PR TITLE
GD-335: Allow to mock `SceneTree`

### DIFF
--- a/addons/gdUnit3/src/core/GdUnitTools.gd
+++ b/addons/gdUnit3/src/core/GdUnitTools.gd
@@ -344,7 +344,7 @@ static func register_auto_free(obj, pool :int):
 		return obj
 	if obj is MainLoop:
 		push_error("avoid to add mainloop to auto_free queue  %s" % obj)
-		return
+		return obj
 	# only register pure objects
 	if obj is GdUnitSceneRunner:
 		_objects_to_delete[pool].push_front(obj)

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -941,3 +941,15 @@ class Foo extends Base:
 func test_mock_with_inheritance_method() -> void:
 	var foo := mock(Foo) as Foo
 	assert_object(foo).is_not_null()
+
+
+func test_change_scene() -> void:
+	var scnene_changer = mock('res://addons/gdUnit3/test/mocker/resources/SceneChanger.gd', CALL_REAL_FUNC)
+	var scene_tree = mock(SceneTree)
+	
+	do_return(scene_tree).on(scnene_changer)._get_tree()
+	
+	scnene_changer._on_ChangeScene_pressed()
+	verify(scene_tree).change_scene("res://some_scene.tscn")
+	
+	scene_tree.free()

--- a/addons/gdUnit3/test/mocker/resources/SceneChanger.gd
+++ b/addons/gdUnit3/test/mocker/resources/SceneChanger.gd
@@ -1,0 +1,13 @@
+extends Node2D
+
+
+func _get_tree() -> SceneTree	:
+	return get_tree()
+
+
+func change_scene() -> void:
+	_get_tree().change_scene("res://some_scene.tscn")
+
+
+func _on_ChangeScene_pressed():
+	change_scene()

--- a/addons/gdUnit3/test/mocker/resources/SceneChanger.tscn
+++ b/addons/gdUnit3/test/mocker/resources/SceneChanger.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/gdUnit3/test/mocker/resources/SceneChanger.gd" type="Script" id=1]
+
+[node name="Node2D" type="Node2D"]
+script = ExtResource( 1 )
+
+[node name="ChangeScene" type="ToolButton" parent="."]
+margin_right = 12.0
+margin_bottom = 22.0
+
+[connection signal="pressed" from="ChangeScene" to="." method="_on_ChangeScene_pressed"]


### PR DESCRIPTION
# Why
I wanted to mock a SceneTree my `mock(SceneTree)` but it returns null.

# What
Allow to mock on a SceneTree, but still report an error because freeing the mainloop will kill the editor.