### PR TITLE
GD-347: Allow to compare real vs int typed dictionary

### DIFF
--- a/addons/gdUnit3/src/core/GdObjects.gd
+++ b/addons/gdUnit3/src/core/GdObjects.gd
@@ -156,11 +156,20 @@ static func equals_sorted(obj_a :Array, obj_b :Array, case_sensitive :bool = fal
 	b.sort()
 	return equals(a, b, case_sensitive)
 
+
+static func is_type_equivalent(type_a, type_b) -> bool:
+	if GdUnitSettings.is_strict_number_type_compare():
+		return type_a == type_b
+	return (
+		(type_a == TYPE_REAL and type_b == TYPE_INT)
+		or (type_a == TYPE_INT and type_b == TYPE_REAL)
+		or type_a == type_b)
+
 static func equals(obj_a, obj_b, case_sensitive :bool = false, deep_check :bool = true ) -> bool:
 	var type_a = typeof(obj_a)
 	var type_b = typeof(obj_b)
-	# is different types
-	if type_a != type_b:
+	# test for type equality if configured
+	if not is_type_equivalent(type_a, type_b):
 		return false
 	# is same instance
 	if obj_a == obj_b:

--- a/addons/gdUnit3/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit3/src/core/GdUnitSettings.gd
@@ -29,8 +29,7 @@ const REPORT_ORPHANS  = REPORT_SETTINGS + "/verbose_orphans"
 const GROUP_ASSERT = REPORT_SETTINGS + "/assert"
 const REPORT_ASSERT_WARNINGS = GROUP_ASSERT + "/verbose_warnings"
 const REPORT_ASSERT_ERRORS   = GROUP_ASSERT + "/verbose_errors"
-
-
+const REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE = GROUP_ASSERT + "/strict_number_type_compare"
 
 # Godot stdout/logging settings
 const CATEGORY_LOGGING := "logging/file_logging/"
@@ -69,6 +68,7 @@ static func setup():
 	create_property_if_need(REPORT_ORPHANS, true, "Enables/Disables orphan reporting.")
 	create_property_if_need(REPORT_ASSERT_ERRORS, true, "Enables/Disables error reporting on asserts.")
 	create_property_if_need(REPORT_ASSERT_WARNINGS, true, "Enables/Disables warning reporting on asserts")
+	create_property_if_need(REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, true, "Enabled/disabled number values will be compared strictly by type. (real vs int)")
 	create_property_if_need(INSPECTOR_NODE_COLLAPSE, true, "Enables/disables that the testsuite node is closed after a successful test run.")
 	create_property_if_need(TEMPLATE_TS_GD, GdUnitTestSuiteDefaultTemplate.DEFAULT_TEMP_TS_GD, "Defines the test suite template")
 
@@ -129,6 +129,9 @@ static func is_verbose_assert_errors() -> bool:
 
 static func is_verbose_orphans() -> bool:
 	return get_setting(REPORT_ORPHANS, true)
+
+static func is_strict_number_type_compare() -> bool:
+	return get_setting(REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, true)
 
 static func is_report_push_errors() -> bool:
 	return get_setting(REPORT_PUSH_ERRORS, false)

--- a/addons/gdUnit3/src/core/_TestCase.gd
+++ b/addons/gdUnit3/src/core/_TestCase.gd
@@ -153,8 +153,8 @@ func test_parameter_index() -> int:
 func test_case_names() -> PoolStringArray:
 	var test_case_names :=  PoolStringArray()
 	var test_name = get_name()
-	for input_values in _test_parameters:
-		test_case_names.append("%s %s" % [test_name, str(input_values)])
+	for index in _test_parameters.size():
+		test_case_names.append("%s:%d %s" % [test_name, index, str(_test_parameters[index])])
 	return test_case_names
 
 func _to_string():

--- a/addons/gdUnit3/test/core/ParameterizedTestCaseTest.gd
+++ b/addons/gdUnit3/test/core/ParameterizedTestCaseTest.gd
@@ -128,3 +128,18 @@ func test_parameterized_dict_values(data: Dictionary, expected :String, test_par
 	
 	collect_test_call("test_parameterized_dict_values", [data, expected])
 	assert_that(str(data)).is_equal(expected)
+
+
+func test_dictionary_div_number_types(
+	value : Dictionary,
+	expected : Dictionary,
+	test_parameters : Array = [
+		[{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0},	{ top = 50, 	bottom = 50,	left = 50,  	right = 50}],
+		[{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0},	{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0}],
+		[{ top = 50,	bottom = 50,	left = 50,  	right = 50},	{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0}],
+		[{ top = 50,	bottom = 50,	left = 50,  	right = 50},	{ top = 50, 	bottom = 50,	left = 50,  	right = 50}],
+	]
+) -> void:
+	# allow to compare type unsave
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, false)
+	assert_that(value).is_equal(expected)

--- a/addons/gdUnit3/test/core/resources/testsuites/TestSuiteParameterizedTests.resource
+++ b/addons/gdUnit3/test/core/resources/testsuites/TestSuiteParameterizedTests.resource
@@ -64,3 +64,15 @@ func test_parameterized_obj_values(a: Object, b :Object, expected :String, test_
 	[TestObj.new("abc"), TestObj.new("def"), "abcdef"]]):
 
 	assert_that(a.to_string()+b.to_string()).is_equal(expected)
+
+func test_dictionary_div_number_types(
+	value : Dictionary,
+	expected : Dictionary,
+	test_parameters : Array = [
+		[{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0},	{ top = 50, 	bottom = 50,	left = 50,  	right = 50}],
+		[{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0},	{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0}],
+		[{ top = 50,	bottom = 50,	left = 50,  	right = 50},	{ top = 50.0,	bottom = 50.0,	left = 50.0,	right = 50.0}],
+		[{ top = 50,	bottom = 50,	left = 50,  	right = 50},	{ top = 50, 	bottom = 50,	left = 50,  	right = 50}],
+	]
+) -> void:
+	assert_that(value).is_equal(expected)


### PR DESCRIPTION
# Why
Comparing a dictionary with diverent number types was result into a failure.
Godot comparing of dictionarys are type save and needs to be handled customized.


# What
- intoduced a new settings to enable/disable number type save comparision.
![image](https://user-images.githubusercontent.com/347037/209696515-2a02ec27-74a9-48e2-96fc-d01e7ec7f766.png)

- fixed ui bug to add failure report to the right tree item
