### PR TITLE
GD-349: Don't report -1 as failure line number at runtime mode

### DIFF
--- a/addons/gdUnit3/src/core/report/GdUnitReport.gd
+++ b/addons/gdUnit3/src/core/report/GdUnitReport.gd
@@ -41,6 +41,8 @@ func is_error() -> bool:
 	return _type == TERMINATED or _type == INTERUPTED or _type == ABORT
 
 func _to_string():
+	if _line_number == -1:
+		return "[color=green]line [/color][color=aqua]<n/a>:[/color] %s" % [_message]
 	return "[color=green]line [/color][color=aqua]%d:[/color] %s" % [_line_number, _message]
 
 func serialize() -> Dictionary:


### PR DESCRIPTION
# Why
When execution test in runtime mode (none debug) the failure line is reported as -1 Godot do not get the stacktrace on runtime mode to extract this information

# What
Instead of reporting -1 report `<n/a>` for not available.