### PR TITLE
GD-358: Fix test parameter parsing of parameterized tests with String arguments

### DIFF
--- a/addons/gdUnit3/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit3/src/core/parse/GdScriptParser.gd
@@ -18,7 +18,7 @@ var TOKEN_FUNCTION_RETURN_TYPE := Token.new("->")
 var TOKEN_FUNCTION_END := Token.new("):")
 var TOKEN_ARGUMENT_ASIGNMENT := Token.new("=")
 var TOKEN_ARGUMENT_TYPE_ASIGNMENT := Token.new(":=")
-var TOKEN_ARGUMENT_FUZZER := FuzzerToken.new(prepare_regex("((?!(fuzzer_(seed|iterations)))fuzzer?\\w+)(=|:=|:Fuzzer=)"))
+var TOKEN_ARGUMENT_FUZZER := FuzzerToken.new(prepare_regex("((?!(fuzzer_(seed|iterations)))fuzzer?\\w+)( ?+= ?+| ?+:= ?+| ?+:Fuzzer ?+= ?+|)"))
 var TOKEN_ARGUMENT_TYPE := Token.new(":")
 var TOKEN_ARGUMENT_SEPARATOR := Token.new(",")
 var TOKEN_BRACKET_OPEN := Token.new("(")
@@ -75,7 +75,7 @@ static func prepare_regex(pattern :String) -> RegEx:
 	return regex
 
 static func clean_up_row(row :String) -> String:
-	return to_unix_format(row.replace(" ", "").replace("	", ""))
+	return to_unix_format(row.replace(" ", "").replace("\t", ""))
 
 static func to_unix_format(input :String) -> String:
 	return input.replace("\r\n", "\n")
@@ -326,18 +326,21 @@ func parse_func_return_type(row: String) -> int:
 		return TYPE_NIL
 	return token.type()
 
-func parse_return_token(row: String) -> Token:
-	var input := clean_up_row(row)
+func parse_return_token(input: String) -> Token:
 	var index := input.find_last(TOKEN_FUNCTION_RETURN_TYPE._token)
 	if index == -1:
 		return TOKEN_NOT_MATCH
-	return next_token(input, index + TOKEN_FUNCTION_RETURN_TYPE._consumed)
+	index += TOKEN_FUNCTION_RETURN_TYPE._consumed
+	var token := next_token(input, index)
+	if token == TOKEN_SPACE:
+		index += TOKEN_SPACE._consumed
+		token = next_token(input, index)
+	return token
 
 # Parses the argument into a argument signature
 # e.g. func foo(arg1 :int, arg2 = 20) -> [arg1, arg2]
-func parse_arguments(row: String) -> Array:
+func parse_arguments(input: String) -> Array:
 	var args := Array()
-	var input := clean_up_row(row)
 	var current_index := 0
 	var token :Token = null
 	var bracket := 0
@@ -345,6 +348,8 @@ func parse_arguments(row: String) -> Array:
 	while current_index < len(input):
 		token = next_token(input, current_index)
 		current_index += token._consumed
+		if token == TOKEN_SPACE:
+			continue
 		if token == TOKEN_BRACKET_OPEN:
 			in_function = true
 			bracket += 1
@@ -375,8 +380,13 @@ func parse_arguments(row: String) -> Array:
 				token = next_token(input, current_index)
 				current_index += token._consumed
 				match token:
+					TOKEN_SPACE:
+						continue
 					TOKEN_ARGUMENT_TYPE:
 						token = next_token(input, current_index)
+						if token == TOKEN_SPACE:
+							current_index += token._consumed
+							token = next_token(input, current_index)
 						arg_type = token._token
 					TOKEN_ARGUMENT_TYPE_ASIGNMENT:
 						arg_value = _parse_end_function(input.substr(current_index), true)
@@ -402,6 +412,7 @@ func parse_arguments(row: String) -> Array:
 					TOKEN_ARGUMENT_SEPARATOR:
 						if bracket <= 1:
 							break
+			arg_value = arg_value.lstrip(" ")
 			if arg_type.empty() and arg_value != GdFunctionArgument.UNDEFINED:
 				var value_type := TYPE_STRING
 				if arg_value.begins_with("Color."):
@@ -507,9 +518,9 @@ func extract_source_code(script_path :PoolStringArray) -> PoolStringArray:
 func extract_func_signature(rows :PoolStringArray, index :int) -> String:
 	var signature = ""
 	for rowIndex in range(index, rows.size()):
-		signature += rows[rowIndex].strip_edges()
+		signature += rows[rowIndex].strip_edges().replace("\t", "")
 		if is_func_end(signature):
-			return clean_up_row(signature)
+			return signature
 	push_error("Can't fully extract function signature of '%s'" % rows[index])
 	return ""
 
@@ -546,11 +557,15 @@ func get_class_name(script :GDScript) -> String:
 
 func parse_func_name(row :String) -> String:
 	var input = clean_up_row(row)
-	var token := next_token(input, 0)
+	var current_index = 0
+	var token := next_token(input, current_index)
+	current_index += token._consumed
 	if token != TOKEN_FUNCTION_STATIC_DECLARATION and token != TOKEN_FUNCTION_DECLARATION:
 		return ""
-	var next := next_token(input, token._consumed)
-	return next._token
+	while not token is Variable:
+		token = next_token(input, current_index)
+		current_index += token._consumed
+	return token._token
 
 func parse_functions(rows :PoolStringArray, clazz_name :String, clazz_path :PoolStringArray, included_functions :PoolStringArray = []) -> Array:
 	var func_descriptors := Array()

--- a/addons/gdUnit3/test/core/GdUnitExecutorTest.gd
+++ b/addons/gdUnit3/test/core/GdUnitExecutorTest.gd
@@ -569,6 +569,7 @@ func test_execute_parameterizied_tests() -> void:
 		"test_dictionary_div_number_types"]
 	assert_array(test_suite.get_children()).extract("get_name").contains_exactly(expected_test_cases)
 	# simulate test suite execution
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, true)
 	var events = yield(execute(test_suite), "completed" )
 	var suite_name = "TestSuiteParameterizedTests"
 	
@@ -595,6 +596,7 @@ func test_execute_parameterizied_tests() -> void:
 	# simulate test suite execution
 	test_suite = resource("res://addons/gdUnit3/test/core/resources/testsuites/TestSuiteParameterizedTests.resource")
 	events = yield(execute(test_suite), "completed" )
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, true)
 	
 	# the test should now be successful
 	assert_array(events).extractv(

--- a/addons/gdUnit3/test/core/ParameterizedTestCaseTest.gd
+++ b/addons/gdUnit3/test/core/ParameterizedTestCaseTest.gd
@@ -143,3 +143,15 @@ func test_dictionary_div_number_types(
 	# allow to compare type unsave
 	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, false)
 	assert_that(value).is_equal(expected)
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_ASSERT_STRICT_NUMBER_TYPE_COMPARE, true)
+
+
+func test_with_string_paramset(
+	value : Array,
+	expected : String,
+	test_parameters : Array = [
+		[ ["a"], "a" ],
+		[ ["a", "very", "long", "argument"], "a very long argument" ],
+	]
+):
+	assert_that(" ".join(value)).is_equal(expected)

--- a/addons/gdUnit3/test/core/ParameterizedTestCaseTest.gd
+++ b/addons/gdUnit3/test/core/ParameterizedTestCaseTest.gd
@@ -147,11 +147,13 @@ func test_dictionary_div_number_types(
 
 
 func test_with_string_paramset(
-	value : Array,
+	values : Array,
 	expected : String,
 	test_parameters : Array = [
 		[ ["a"], "a" ],
 		[ ["a", "very", "long", "argument"], "a very long argument" ],
 	]
 ):
-	assert_that(" ".join(value)).is_equal(expected)
+	# do join via 'PoolStringArray' to be compatible with Godot 3.4.x
+	var current := PoolStringArray(values).join(" ")
+	assert_that(current.strip_edges()).is_equal(expected)

--- a/addons/gdUnit3/test/core/TestSuiteScannerTest.gd
+++ b/addons/gdUnit3/test/core/TestSuiteScannerTest.gd
@@ -256,12 +256,12 @@ func test_parse_and_add_test_cases() -> void:
 		.contains_exactly([
 			tuple("test_no_args", default_time, PoolStringArray(), 1),
 			tuple("test_with_timeout", 2000, PoolStringArray(), 1),
-			tuple("test_with_fuzzer", default_time, PoolStringArray(["fuzzer:=Fuzzers.rangei(-10,22)"]), Fuzzer.ITERATION_DEFAULT_COUNT),
-			tuple("test_with_fuzzer_iterations", default_time, PoolStringArray(["fuzzer:=Fuzzers.rangei(-10,22)"]), 10),
-			tuple("test_with_multible_fuzzers", default_time, PoolStringArray(["fuzzer_a:=Fuzzers.rangei(-10,22)", "fuzzer_b:=Fuzzers.rangei(23,42)"]), 10),
-			tuple("test_multiline_arguments_a", default_time, PoolStringArray(["fuzzer_a:=Fuzzers.rangei(-10,22)", "fuzzer_b:=Fuzzers.rangei(23,42)"]), 42),
-			tuple("test_multiline_arguments_b", default_time, PoolStringArray(["fuzzer_a:=Fuzzers.rangei(-10,22)", "fuzzer_b:=Fuzzers.rangei(23,42)"]), 23),
-			tuple("test_multiline_arguments_c", 2000, PoolStringArray(["fuzzer_a:=Fuzzers.rangei(-10,22)", "fuzzer_b:=Fuzzers.rangei(23,42)"]), 33),
+			tuple("test_with_fuzzer", default_time, PoolStringArray(["fuzzer:=Fuzzers.rangei(-10, 22)"]), Fuzzer.ITERATION_DEFAULT_COUNT),
+			tuple("test_with_fuzzer_iterations", default_time, PoolStringArray(["fuzzer:=Fuzzers.rangei(-10, 22)"]), 10),
+			tuple("test_with_multible_fuzzers", default_time, PoolStringArray(["fuzzer_a:=Fuzzers.rangei(-10, 22)", "fuzzer_b:=Fuzzers.rangei(23, 42)"]), 10),
+			tuple("test_multiline_arguments_a", default_time, PoolStringArray(["fuzzer_a:=Fuzzers.rangei(-10, 22)", "fuzzer_b:=Fuzzers.rangei(23, 42)"]), 42),
+			tuple("test_multiline_arguments_b", default_time, PoolStringArray(["fuzzer_a:=Fuzzers.rangei(-10, 22)", "fuzzer_b:=Fuzzers.rangei(23, 42)"]), 23),
+			tuple("test_multiline_arguments_c", 2000, PoolStringArray(["fuzzer_a:=Fuzzers.rangei(-10, 22)", "fuzzer_b:=Fuzzers.rangei(23, 42)"]), 33),
 		])
 
 func test_scan_by_inheritance_class_name() -> void:

--- a/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit3/test/core/parse/GdScriptParserTest.gd
@@ -79,7 +79,7 @@ func test_parse_arguments():
 		.contains_exactly([
 			GdFunctionArgument.new("a", "int"),
 			GdFunctionArgument.new("b", "int"),
-			GdFunctionArgument.new("parameters", "Array", "[[1,2],[3,4],[5,6]]")])
+			GdFunctionArgument.new("parameters", "Array", "[[1, 2], [3, 4], [5, 6]]")])
 	
 	assert_array(_parser.parse_arguments("func test_values(a:Vector2, b:Vector2, expected:Vector2, test_parameters:=[[Vector2.ONE,Vector2.ONE,Vector2(1,1)]]):"))\
 		.contains_exactly([
@@ -156,12 +156,12 @@ func test_parse_arguments_default_build_in_type_Array():
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Array=[1, 2, 3]):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", "String"),
-			GdFunctionArgument.new("arg2", "Array", "[1,2,3]")])
+			GdFunctionArgument.new("arg2", "Array", "[1, 2, 3]")])
 	
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :=[1, 2, 3]):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", "String"),
-			GdFunctionArgument.new("arg2", "Array", "[1,2,3]")])
+			GdFunctionArgument.new("arg2", "Array", "[1, 2, 3]")])
 	
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2=[]):")) \
 		.contains_exactly([
@@ -171,7 +171,7 @@ func test_parse_arguments_default_build_in_type_Array():
 	assert_array(_parser.parse_arguments("func foo(arg1 :String, arg2 :Array=[1, 2, 3], arg3 := false):")) \
 		.contains_exactly([
 			GdFunctionArgument.new("arg1", "String"),
-			GdFunctionArgument.new("arg2", "Array", "[1,2,3]"),
+			GdFunctionArgument.new("arg2", "Array", "[1, 2, 3]"),
 			GdFunctionArgument.new("arg3", "bool", "false")])
 
 func test_parse_arguments_default_build_in_type_Color():
@@ -313,14 +313,15 @@ func test_extract_function_signature() -> void:
 	var rows = _parser.extract_source_code(path)
 	
 	assert_that(_parser.extract_func_signature(rows, 9))\
-		.is_equal("funca1(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false)->void:")
+		.is_equal('func a1(set_name:String, path:String="", load_on_init:bool=false,set_auto_save:bool=false, set_network_sync:bool=false) -> void:')
 	assert_that(_parser.extract_func_signature(rows, 14))\
-		.is_equal("funca2(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false)->void:")
+		.is_equal('func a2(set_name:String, path:String="", load_on_init:bool=false,set_auto_save:bool=false, set_network_sync:bool=false) -> void:')
 	assert_that(_parser.extract_func_signature(rows, 19))\
-		.is_equal("funca3(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false):")
+		.is_equal('func a3(set_name:String, path:String="", load_on_init:bool=false,set_auto_save:bool=false, set_network_sync:bool=false) :')
 	assert_that(_parser.extract_func_signature(rows, 24))\
-		.is_equal("funca4(set_name:String,path:String=\"\",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false):")
-
+		.is_equal('func a4(set_name:String,path:String="",load_on_init:bool=false,set_auto_save:bool=false,set_network_sync:bool=false):')
+	assert_that(_parser.extract_func_signature(rows, 32))\
+		.is_equal('func a5(value : Array,expected : String,test_parameters : Array = [[ ["a"], "a" ],[ ["a", "very", "long", "argument"], "a very long argument" ],]):')
 
 func test_strip_leading_spaces():
 	assert_str(GdScriptParser.TokenInnerClass._strip_leading_spaces("")).is_empty()
@@ -455,7 +456,7 @@ func test_extract_func_signature_multiline() -> void:
 	]
 	var fs = _parser.extract_func_signature(source_code, 0)
 	
-	assert_that(fs).is_equal("functest_parameterized(a:int,b:int,c:int,expected:int,parameters=[[1,2,3,6],[3,4,5,11],[6,7,8,21]]):")
+	assert_that(fs).is_equal("func test_parameterized(a: int, b :int, c :int, expected :int, parameters = [[1, 2, 3, 6],[3, 4, 5, 11],[6, 7, 8, 21] ]):")
 
 func test_parse_func_description_paramized_test():
 	var fd = _parser.parse_func_description("functest_parameterized(a:int,b:int,c:int,expected:int,parameters=[[1,2,3,6],[3,4,5,11],[6,7,8,21]]):", "class", ["path"], 22)
@@ -469,11 +470,13 @@ func test_parse_func_description_paramized_test():
 	]))
 
 func test_parse_func_descriptor_with_fuzzers():
-	var source_code = ["func test_foo(fuzzer_a = fuzz_a(), fuzzer_b := fuzz_b(),\n",
-		"fuzzer_c :Fuzzer = fuzz_c(),\n",
-		"fuzzer = Fuzzers.random_rangei(-23, 22),\n",
-		"fuzzer_iterations = 234,\n",
-		"fuzzer_seed = 100):\n"]
+	var source_code := """
+	func test_foo(fuzzer_a = fuzz_a(), fuzzer_b := fuzz_b(),
+		fuzzer_c :Fuzzer = fuzz_c(),
+		fuzzer = Fuzzers.random_rangei(-23, 22),
+		fuzzer_iterations = 234,
+		fuzzer_seed = 100):
+	""".split("\n")
 	var fs = _parser.extract_func_signature(source_code, 0)
 	var fd = _parser.parse_func_description(fs, "class", ["path"], 22)
 	
@@ -481,7 +484,7 @@ func test_parse_func_descriptor_with_fuzzers():
 		GdFunctionArgument.new("fuzzer_a", "Fuzzer", "fuzz_a()"),
 		GdFunctionArgument.new("fuzzer_b", "Fuzzer", "fuzz_b()"),
 		GdFunctionArgument.new("fuzzer_c", "Fuzzer", "fuzz_c()"),
-		GdFunctionArgument.new("fuzzer", "Fuzzer", "Fuzzers.random_rangei(-23,22)"),
+		GdFunctionArgument.new("fuzzer", "Fuzzer", "Fuzzers.random_rangei(-23, 22)"),
 		GdFunctionArgument.new("fuzzer_iterations", "int", "234"),
 		GdFunctionArgument.new("fuzzer_seed", "int", "100")
 	]))

--- a/addons/gdUnit3/test/mocker/resources/ClassWithCustomFormattings.gd
+++ b/addons/gdUnit3/test/mocker/resources/ClassWithCustomFormattings.gd
@@ -29,3 +29,13 @@ func a4(set_name:String,
 	set_network_sync:bool=false
 ):
 	pass
+
+func a5(
+	value : Array,
+	expected : String,
+	test_parameters : Array = [
+		[ ["a"], "a" ],
+		[ ["a", "very", "long", "argument"], "a very long argument" ],
+	]
+):
+	pass


### PR DESCRIPTION
# Why
Using Strings containing spaces or tabs was failing on parameterized tests. The valus was distorted.

# What
- Fix the test argument parsing by do not clean up the function signature to pare the arguments
- Fix also failing GdUnitExecutor test based on changed gdunit settings during test run