### PR TITLE
GD-362: Spy on a implemented virtual function like _input is not working

### DIFF
--- a/addons/gdUnit3/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit3/src/asserts/GdAssertMessages.gd
@@ -30,6 +30,8 @@ static func _current(value, delimiter ="\n") -> String:
 		TYPE_REAL:
 			return "'[color=%s]%f[/color]'" % [VALUE_COLOR, value]
 		TYPE_OBJECT:
+			if value == null:
+				return "'[color=%s]<null>[/color]'" % [VALUE_COLOR]
 			if value is InputEvent:
 				return "[color=%s]<%s>[/color]" % [VALUE_COLOR, value.as_text()]
 			#if value.has_method("_to_string"):
@@ -49,6 +51,8 @@ static func _expected(value, delimiter ="\n") -> String:
 		TYPE_REAL:
 			return "'[color=%s]%f[/color]'" % [VALUE_COLOR, value]
 		TYPE_OBJECT:
+			if value == null:
+				return "'[color=%s]<null>[/color]'" % [VALUE_COLOR]
 			if value is InputEvent:
 				return "[color=%s]<%s>[/color]" % [VALUE_COLOR, value.as_text()]
 			#if value.has_method("_to_string"):

--- a/addons/gdUnit3/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit3/src/asserts/GdAssertMessages.gd
@@ -30,6 +30,8 @@ static func _current(value, delimiter ="\n") -> String:
 		TYPE_REAL:
 			return "'[color=%s]%f[/color]'" % [VALUE_COLOR, value]
 		TYPE_OBJECT:
+			if value is InputEvent:
+				return "[color=%s]<%s>[/color]" % [VALUE_COLOR, value.as_text()]
 			#if value.has_method("_to_string"):
 			#	return "[color=%s]<%s>[/color]" % [VALUE_COLOR, value._to_string()]
 			return "[color=%s]<%s>[/color]" % [VALUE_COLOR, value.get_class()]
@@ -47,6 +49,8 @@ static func _expected(value, delimiter ="\n") -> String:
 		TYPE_REAL:
 			return "'[color=%s]%f[/color]'" % [VALUE_COLOR, value]
 		TYPE_OBJECT:
+			if value is InputEvent:
+				return "[color=%s]<%s>[/color]" % [VALUE_COLOR, value.as_text()]
 			#if value.has_method("_to_string"):
 			#	return "[color=%s]<%s>[/color]" % [VALUE_COLOR, value._to_string()]
 			return "[color=%s]<%s>[/color]" % [VALUE_COLOR, value.get_class()]
@@ -331,7 +335,7 @@ static func error_no_more_interactions(summary :Dictionary) -> String:
 	for args in summary.keys():
 		var times :int = summary[args]
 		interactions.append(_format_arguments(args, times))
-	return "%s\n%s\n%s" % [_error("Expecting no more interacions!"), _error("But found interactions on:"), interactions.join("\n")] 
+	return "%s\n%s\n%s" % [_error("Expecting no more interactions!"), _error("But found interactions on:"), interactions.join("\n")]
 
 static func error_validate_interactions(current_interactions :Dictionary, expected_interactions :Dictionary) -> String:
 	var interactions := PoolStringArray()
@@ -339,7 +343,7 @@ static func error_validate_interactions(current_interactions :Dictionary, expect
 		var times :int = current_interactions[args]
 		interactions.append(_format_arguments(args, times))
 	var expected_interaction := _format_arguments(expected_interactions.keys()[0], expected_interactions.values()[0])
-	return "%s\n%s\n%s\n%s" % [_error("Expecting interacion on:"), expected_interaction, _error("But found interactions on:"), interactions.join("\n")]
+	return "%s\n%s\n%s\n%s" % [_error("Expecting interaction on:"), expected_interaction, _error("But found interactions on:"), interactions.join("\n")]
 
 static func _format_arguments(args :Array, times :int) -> String:
 	var fname :String = args[0]
@@ -348,10 +352,15 @@ static func _format_arguments(args :Array, times :int) -> String:
 	var fsignature := _current("%s(%s)" % [fname, typed_args.join(", ")])
 	return "	%s	%d time's" % [fsignature, times]
 
+static func _format_arg(arg) -> String:
+	if arg is InputEvent:
+		return arg.as_text()
+	return str(arg)
+
 static func _to_typed_args(args :Array) -> PoolStringArray:
 	var typed := PoolStringArray()
 	for arg in args:
-		typed.append( str(arg) + " :" + GdObjects.type_as_string(typeof(arg)))
+		typed.append(_format_arg(arg) + " :" + GdObjects.type_as_string(typeof(arg)))
 	return typed
 
 static func _find_first_diff( left :Array, right :Array) -> String:

--- a/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitAssertImpl.gd
@@ -18,6 +18,9 @@ static func _get_line_number() -> int:
 		return -1
 	for stack_info in stack_trace:
 		var function :String = stack_info.get("function")
+		# we catch helper asserts to skip over to return the correct line number
+		if function.begins_with("assert_"):
+			continue
 		var source :String = stack_info.get("source")
 		if source.empty() \
 		 or source.ends_with("AssertImpl.gd") \

--- a/addons/gdUnit3/src/asserts/GdUnitSignalAssertImpl.gd
+++ b/addons/gdUnit3/src/asserts/GdUnitSignalAssertImpl.gd
@@ -97,6 +97,8 @@ class SignalCollector:
 	
 	func match(emitter :Object, signal_name :String, args :Array) -> bool:
 		#prints("match", signal_name,  _collected_signals[emitter][signal_name]);
+		if _collected_signals.empty():
+			return false
 		for received_args in _collected_signals[emitter][signal_name]:
 			#prints("testing", signal_name, received_args, "vs", args)
 			if GdObjects.equals(received_args, args):

--- a/addons/gdUnit3/src/core/GdObjects.gd
+++ b/addons/gdUnit3/src/core/GdObjects.gd
@@ -229,10 +229,6 @@ static func equals(obj_a, obj_b, case_sensitive :bool = false, deep_check :bool 
 					return false
 				if obj_a.get_class() != obj_b.get_class():
 					return false
-				# verify is different instance id, we exclude explicit the InputEvent to allow deep comapare on it
-				if not (obj_a is InputEvent or obj_b is InputEvent):
-					if obj_a.get_instance_id() != obj_b.get_instance_id():
-						return false
 				var a = inst2dict(obj_a) if is_instance_valid(obj_a) and obj_a.get_script() != null else var2str(obj_a)
 				var b = inst2dict(obj_b) if is_instance_valid(obj_b) and obj_b.get_script() != null else var2str(obj_b)
 				return str(a) == str(b)

--- a/addons/gdUnit3/src/core/GdObjects.gd
+++ b/addons/gdUnit3/src/core/GdObjects.gd
@@ -165,6 +165,45 @@ static func is_type_equivalent(type_a, type_b) -> bool:
 		or (type_a == TYPE_INT and type_b == TYPE_REAL)
 		or type_a == type_b)
 
+# prototype of better object to dictionary
+static func obj2dict(obj :Object, hashed_objects := Dictionary()) -> Dictionary:
+	if obj == null:
+		return {}
+	var clazz_name := obj.get_class()
+	var dict := Dictionary()
+	var clazz_path := ""
+	
+	if is_instance_valid(obj) and obj.get_script() != null:
+		var d := inst2dict(obj)
+		clazz_path = d["@path"]
+		if d["@subpath"] != NodePath(""):
+			clazz_name = d["@subpath"]
+			dict["@inner_class"] = true
+		else:
+			clazz_name = clazz_path.get_file().replace(".gd", "")
+	dict["@path"] = clazz_path
+	
+	for property in obj.get_property_list():
+		var property_name = property["name"]
+		var property_type = property["type"]
+		var property_value = obj.get(property_name)
+		if property_value is GDScript:
+			continue
+		if (property["usage"] & PROPERTY_USAGE_SCRIPT_VARIABLE|PROPERTY_USAGE_DEFAULT
+			and not property["usage"] & PROPERTY_USAGE_CATEGORY
+			and not property["usage"] == 0):
+			if property_type == TYPE_OBJECT:
+				# prevent recursion
+				if hashed_objects.has(obj):
+					dict[property_name] = str(property_value)
+					continue
+				hashed_objects[obj] = true
+				dict[property_name] = obj2dict(property_value, hashed_objects)
+			else:
+				dict[property_name] = "%d:%s" % [property_type, property_value]
+	return {"%s" % clazz_name : dict}
+
+
 static func equals(obj_a, obj_b, case_sensitive :bool = false, deep_check :bool = true ) -> bool:
 	var type_a = typeof(obj_a)
 	var type_b = typeof(obj_b)
@@ -179,12 +218,23 @@ static func equals(obj_a, obj_b, case_sensitive :bool = false, deep_check :bool 
 		return false
 	if obj_b == null and obj_a != null:
 		return false
-
+	
 	match type_a:
 		TYPE_OBJECT:
 			if deep_check:
-				var a = var2str(obj_a) if obj_a.get_script() == null else inst2dict(obj_a)
-				var b = var2str(obj_b) if obj_b.get_script() == null else inst2dict(obj_b)
+				# prototype of better deep check
+				#return equals(obj2dict(obj_a), obj2dict(obj_b))
+				# fail fast
+				if not is_instance_valid(obj_a) or not is_instance_valid(obj_b):
+					return false
+				if obj_a.get_class() != obj_b.get_class():
+					return false
+				# verify is different instance id, we exclude explicit the InputEvent to allow deep comapare on it
+				if not (obj_a is InputEvent or obj_b is InputEvent):
+					if obj_a.get_instance_id() != obj_b.get_instance_id():
+						return false
+				var a = inst2dict(obj_a) if is_instance_valid(obj_a) and obj_a.get_script() != null else var2str(obj_a)
+				var b = inst2dict(obj_b) if is_instance_valid(obj_b) and obj_b.get_script() != null else var2str(obj_b)
 				return str(a) == str(b)
 			return obj_a == obj_b
 		TYPE_ARRAY:

--- a/addons/gdUnit3/src/core/GdUnitClassDoubler.gd
+++ b/addons/gdUnit3/src/core/GdUnitClassDoubler.gd
@@ -5,7 +5,7 @@ extends Reference
 const EXCLUDE_VIRTUAL_FUNCTIONS = [
 	# we have to exclude notifications because NOTIFICATION_PREDELETE is try
 	# to delete already freed spy/mock resources and will result in a conflict
-	"_notification", 
+	"_notification",
 	]
 
 # define functions to be exclude when spy or mock on a scene
@@ -52,7 +52,7 @@ static func get_extends_clazz(clazz_name :String, clazz_path :PoolStringArray) -
 	return clazz_name
 
 # double all functions of given instance
-static func double_functions(clazz_name :String, clazz_path :PoolStringArray, func_doubler: GdFunctionDoubler, exclude_functions :Array) -> PoolStringArray:
+static func double_functions(instance :Object, clazz_name :String, clazz_path :PoolStringArray, func_doubler: GdFunctionDoubler, exclude_functions :Array) -> PoolStringArray:
 	var doubled_source := PoolStringArray()
 	var parser := GdScriptParser.new()
 	var exclude_override_functions := EXCLUDE_VIRTUAL_FUNCTIONS + EXCLUDE_FUNCTIONS + exclude_functions
@@ -77,6 +77,9 @@ static func double_functions(clazz_name :String, clazz_path :PoolStringArray, fu
 	for method in clazz_functions:
 		var func_descriptor := GdFunctionDescriptor.extract_from(method)
 		if functions.has(func_descriptor.name()) or exclude_override_functions.has(func_descriptor.name()):
+			continue
+		# do not double on not implemented virtual functions
+		if instance != null and not instance.has_method(func_descriptor.name()):
 			continue
 		functions.append(func_descriptor.name())
 		doubled_source += func_doubler.double(func_descriptor)

--- a/addons/gdUnit3/src/core/GdUnitObjectInteractionsTemplate.gd
+++ b/addons/gdUnit3/src/core/GdUnitObjectInteractionsTemplate.gd
@@ -7,7 +7,12 @@ var __verified_interactions := Array()
 var __caller :Object
 
 func __save_function_interaction(args :Array) -> void:
-	__saved_interactions[args] = __saved_interactions.get(args, 0) + 1
+	var matcher := GdUnitArgumentMatchers.to_matcher(args)
+	for key in __saved_interactions.keys():
+		if matcher.is_match(key):
+			__saved_interactions[key] += 1
+			return
+	__saved_interactions[args] = 1
 
 func __is_verify_interactions() -> bool:
 	return __expected_interactions != -1

--- a/addons/gdUnit3/src/core/GdUnitObjectInteractionsTemplate.gd
+++ b/addons/gdUnit3/src/core/GdUnitObjectInteractionsTemplate.gd
@@ -7,7 +7,7 @@ var __verified_interactions := Array()
 var __caller :Object
 
 func __save_function_interaction(args :Array) -> void:
-	var matcher := GdUnitArgumentMatchers.to_matcher(args)
+	var matcher := GdUnitArgumentMatchers.to_matcher(args, true)
 	for key in __saved_interactions.keys():
 		if matcher.is_match(key):
 			__saved_interactions[key] += 1
@@ -25,7 +25,7 @@ func __do_verify_interactions(times :int = 1, expect_result :int = GdUnitAssert.
 func __verify_interactions(args :Array):
 	var summary := Dictionary()
 	var total_interactions := 0
-	var matcher := GdUnitArgumentMatchers.to_matcher(args)
+	var matcher := GdUnitArgumentMatchers.to_matcher(args, true)
 	for key in __saved_interactions.keys():
 		if matcher.is_match(key):
 			var interactions :int = __saved_interactions.get(key, 0)

--- a/addons/gdUnit3/src/matchers/EqualsArgumentMatcher.gd
+++ b/addons/gdUnit3/src/matchers/EqualsArgumentMatcher.gd
@@ -2,10 +2,21 @@ class_name EqualsArgumentMatcher
 extends GdUnitArgumentMatcher
 
 var _current
+var _auto_deep_check_mode
 
-func _init(current):
+func _init(current, auto_deep_check_mode := false):
 	_current = current
+	_auto_deep_check_mode = auto_deep_check_mode
 
 func is_match(value) -> bool:
-	# test case sensitive
-	return GdObjects.equals(_current, value, true, true)
+	# is auto deep compare mode requested
+	var deep_check := deep_check_on(value)
+	var case_sensitive_check := true
+	return GdObjects.equals(_current, value, case_sensitive_check, deep_check)
+
+func deep_check_on(value) -> bool:
+	var deep_check := false
+	if _auto_deep_check_mode and is_instance_valid(value):
+		# we do deep check on all InputEvent's
+		deep_check = value is InputEvent
+	return deep_check

--- a/addons/gdUnit3/src/matchers/EqualsArgumentMatcher.gd
+++ b/addons/gdUnit3/src/matchers/EqualsArgumentMatcher.gd
@@ -7,5 +7,5 @@ func _init(current):
 	_current = current
 
 func is_match(value) -> bool:
-	# test case sensitive and with no deep check
-	return GdObjects.equals(_current, value, true, false)
+	# test case sensitive
+	return GdObjects.equals(_current, value, true, true)

--- a/addons/gdUnit3/src/matchers/GdUnitArgumentMatchers.gd
+++ b/addons/gdUnit3/src/matchers/GdUnitArgumentMatchers.gd
@@ -10,7 +10,7 @@ func _init():
 		_instances[build_in_type] = AnyBuildInTypeArgumentMatcher.new(build_in_type)
 	_instances[TYPE_ANY] = AnyArgumentMatcher.new()
 
-static func to_matcher(arguments :Array) -> ChainedArgumentMatcher:
+static func to_matcher(arguments :Array, auto_deep_check_mode := false) -> ChainedArgumentMatcher:
 	var matchers := Array()
 	for arg in arguments:
 		# argument is already a matcher
@@ -18,7 +18,7 @@ static func to_matcher(arguments :Array) -> ChainedArgumentMatcher:
 			matchers.append(arg)
 		else:
 			# pass argument into equals matcher
-			matchers.append(EqualsArgumentMatcher.new(arg))
+			matchers.append(EqualsArgumentMatcher.new(arg, auto_deep_check_mode))
 	return ChainedArgumentMatcher.new(matchers)
 
 static func any() -> GdUnitArgumentMatcher:

--- a/addons/gdUnit3/src/mocking/GdUnitMockBuilder.gd
+++ b/addons/gdUnit3/src/mocking/GdUnitMockBuilder.gd
@@ -210,7 +210,7 @@ static func mock_on_script(clazz, function_excludes :PoolStringArray, debug_writ
 	var push_errors := is_push_error_enabled()
 	var function_doubler := MockFunctionDoubler.new(push_errors)
 	var lines := load_template(GdUnitMockImpl, clazz_name, clazz_path)
-	lines += double_functions(clazz_name, clazz_path, function_doubler, function_excludes)
+	lines += double_functions(null, clazz_name, clazz_path, function_doubler, function_excludes)
 	
 	var mock := GDScript.new()
 	mock.source_code = lines.join("\n")

--- a/addons/gdUnit3/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit3/src/spy/GdUnitSpyBuilder.gd
@@ -81,7 +81,6 @@ class SpyFunctionDoubler extends GdFunctionDoubler:
 		var func_name := func_descriptor.name()
 		var args := func_descriptor.args()
 		var varargs := func_descriptor.varargs()
-		var default_return_value = return_value(func_descriptor.return_type())
 		var arg_names := extract_arg_names(args)
 		var vararg_names := extract_arg_names(varargs)
 		
@@ -92,15 +91,14 @@ class SpyFunctionDoubler extends GdFunctionDoubler:
 			return PoolStringArray([constructor])
 		
 		var double := func_signature + "\n"
-		var func_template := get_template(default_return_value, is_vararg, not arg_names.empty())
+		var func_template := get_template(func_descriptor.return_type(), is_vararg, not arg_names.empty())
 		# fix to  unix format, this is need when the template is edited under windows than the template is stored with \r\n
 		func_template = GdScriptParser.to_unix_format(func_template)
 		double += func_template\
 			.replace("$(args)", str(arg_names))\
 			.replace("$(varargs)", str(vararg_names)) \
 			.replace("$(func_name)", func_name )\
-			.replace("$(func_arg)", arg_names.join(", ")) \
-			.replace("${default_return_value}", default_return_value)
+			.replace("$(func_arg)", arg_names.join(", "))
 		
 		if is_static:
 			double = double.replace("", "__self[0].__instance_delegator" if is_engine else "")\
@@ -110,12 +108,12 @@ class SpyFunctionDoubler extends GdFunctionDoubler:
 				.replace("$(instance)", "")
 		return double.split("\n")
 		
-	func get_template(return_type, is_vararg :bool, has_args :bool) -> String:
+	func get_template(return_type :int, is_vararg :bool, has_args :bool) -> String:
 		if is_vararg and has_args:
 			return SPY_VOID_TEMPLATE_VARARG
 		if is_vararg and not has_args:
 			return SPY_VOID_TEMPLATE_VARARG_ONLY
-		if return_type == "void":
+		if return_type == TYPE_NIL or return_type == GdObjects.TYPE_VOID:
 			return SPY_VOID_TEMPLATE
 		return SPY_TEMPLATE
 

--- a/addons/gdUnit3/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit3/src/spy/GdUnitSpyBuilder.gd
@@ -8,9 +8,7 @@ const SPY_TEMPLATE = \
 		return $(instance)__verify_interactions(args)
 	else:
 		$(instance)__save_function_interaction(args)
-	if $(is_virtual) == false:
-		return .$(func_name)($(func_arg))
-	return ${default_return_value}
+	return .$(func_name)($(func_arg))
 """
 
 const SPY_VOID_TEMPLATE = \
@@ -21,8 +19,7 @@ const SPY_VOID_TEMPLATE = \
 		return
 	else:
 		$(instance)__save_function_interaction(args)
-	if $(is_virtual) == false:
-		.$(func_name)($(func_arg))
+	.$(func_name)($(func_arg))
 """
 
 const SPY_VOID_TEMPLATE_VARARG =\
@@ -35,19 +32,18 @@ const SPY_VOID_TEMPLATE_VARARG =\
 	else:
 		$(instance)__save_function_interaction(args)
 	
-	if $(is_virtual) == false:
-		match varargs.size():
-			0: .$(func_name)($(func_arg))
-			1: .$(func_name)($(func_arg), varargs[0])
-			2: .$(func_name)($(func_arg), varargs[0], varargs[1])
-			3: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2])
-			4: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3])
-			5: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3], varargs[4])
-			6: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5])
-			7: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6])
-			8: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7])
-			9: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8])
-			10: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8], varargs[9])
+	match varargs.size():
+		0: .$(func_name)($(func_arg))
+		1: .$(func_name)($(func_arg), varargs[0])
+		2: .$(func_name)($(func_arg), varargs[0], varargs[1])
+		3: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2])
+		4: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3])
+		5: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3], varargs[4])
+		6: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5])
+		7: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6])
+		8: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7])
+		9: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8])
+		10: .$(func_name)($(func_arg), varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8], varargs[9])
 """
 
 const SPY_VOID_TEMPLATE_VARARG_ONLY =\
@@ -60,19 +56,18 @@ const SPY_VOID_TEMPLATE_VARARG_ONLY =\
 	else:
 		$(instance)__save_function_interaction(args)
 	
-	if $(is_virtual) == false:
-		match varargs.size():
-			0: .$(func_name)()
-			1: .$(func_name)(varargs[0])
-			2: .$(func_name)(varargs[0], varargs[1])
-			3: .$(func_name)(varargs[0], varargs[1], varargs[2])
-			4: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3])
-			5: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4])
-			6: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5])
-			7: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6])
-			8: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7])
-			9: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8])
-			10: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8], varargs[9])
+	match varargs.size():
+		0: .$(func_name)()
+		1: .$(func_name)(varargs[0])
+		2: .$(func_name)(varargs[0], varargs[1])
+		3: .$(func_name)(varargs[0], varargs[1], varargs[2])
+		4: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3])
+		5: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4])
+		6: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5])
+		7: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6])
+		8: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7])
+		9: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8])
+		10: .$(func_name)(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8], varargs[9])
 """
 
 class SpyFunctionDoubler extends GdFunctionDoubler:
@@ -80,7 +75,6 @@ class SpyFunctionDoubler extends GdFunctionDoubler:
 	
 	func double(func_descriptor :GdFunctionDescriptor) -> PoolStringArray:
 		var func_signature := func_descriptor.typeless()
-		var is_virtual := func_descriptor.is_virtual()
 		var is_static := func_descriptor.is_static()
 		var is_engine := func_descriptor.is_engine()
 		var is_vararg := func_descriptor.is_vararg()
@@ -104,7 +98,6 @@ class SpyFunctionDoubler extends GdFunctionDoubler:
 		double += func_template\
 			.replace("$(args)", str(arg_names))\
 			.replace("$(varargs)", str(vararg_names)) \
-			.replace("$(is_virtual)", str(is_virtual).to_lower()) \
 			.replace("$(func_name)", func_name )\
 			.replace("$(func_arg)", arg_names.join(", ")) \
 			.replace("${default_return_value}", default_return_value)
@@ -168,7 +161,7 @@ static func spy_on_script(instance, function_excludes :PoolStringArray, debug_wr
 	
 	var clazz_path := GdObjects.extract_class_path(instance)
 	var lines := load_template(GdUnitSpyImpl, extends_clazz, clazz_path)
-	lines += double_functions(extends_clazz, clazz_path, SpyFunctionDoubler.new(), function_excludes)
+	lines += double_functions(instance, extends_clazz, clazz_path, SpyFunctionDoubler.new(), function_excludes)
 	
 	var spy := GDScript.new()
 	spy.source_code = lines.join("\n")

--- a/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
+++ b/addons/gdUnit3/test/mocker/GdUnitMockerTest.gd
@@ -15,7 +15,7 @@ func assert_last_error(expected :String):
 	var gd_assert := GdUnitAssertImpl.new(self, "")
 	if Engine.has_meta(GdAssertReports.LAST_ERROR):
 		gd_assert._current_error_message = Engine.get_meta(GdAssertReports.LAST_ERROR)
-	gd_assert.has_failure_message(expected)
+	gd_assert.has_failure_message(expected.dedent().trim_prefix("\n"))
 
 func test_is_mockable_godot_classes():
 	# verify enigne classes
@@ -647,11 +647,11 @@ func test_verify_fail():
 	
 	# verify should fail because we interacts two times and not one
 	verify(mocked_node, 1, GdUnitAssert.EXPECT_FAIL).set_process(true)
-	var expected_error := """Expecting interacion on:
-	'set_process(True :bool)'	1 time's
-But found interactions on:
-	'set_process(True :bool)'	2 time's"""
-	expected_error = GdScriptParser.to_unix_format(expected_error)
+	var expected_error := """
+		Expecting interaction on:
+			'set_process(True :bool)'	1 time's
+		But found interactions on:
+			'set_process(True :bool)'	2 time's"""
 	assert_last_error(expected_error)
 
 func test_verify_func_interaction_wiht_PoolStringArray():
@@ -669,10 +669,11 @@ func test_verify_func_interaction_wiht_PoolStringArray_fail():
 	
 	# try to verify with default array type instead of PoolStringArray type
 	verify(mocked, 1, GdUnitAssert.EXPECT_FAIL).set_values([])
-	var expected_error := """Expecting interacion on:
-	'set_values([] :Array)'	1 time's
-But found interactions on:
-	'set_values([] :PoolStringArray)'	1 time's"""
+	var expected_error := """
+		Expecting interaction on:
+			'set_values([] :Array)'	1 time's
+		But found interactions on:
+			'set_values([] :PoolStringArray)'	1 time's"""
 	expected_error = GdScriptParser.to_unix_format(expected_error)
 	assert_last_error(expected_error)
 	
@@ -682,12 +683,13 @@ But found interactions on:
 	mocked.set_values(PoolStringArray(["a", "b"]))
 	mocked.set_values([1, 2])
 	verify(mocked, 1, GdUnitAssert.EXPECT_FAIL).set_values([])
-	expected_error = """Expecting interacion on:
-	'set_values([] :Array)'	1 time's
-But found interactions on:
-	'set_values([] :PoolStringArray)'	1 time's
-	'set_values([a, b] :PoolStringArray)'	1 time's
-	'set_values([1, 2] :Array)'	1 time's"""
+	expected_error = """
+		Expecting interaction on:
+			'set_values([] :Array)'	1 time's
+		But found interactions on:
+			'set_values([] :PoolStringArray)'	1 time's
+			'set_values([a, b] :PoolStringArray)'	1 time's
+			'set_values([1, 2] :Array)'	1 time's"""
 	expected_error = GdScriptParser.to_unix_format(expected_error)
 	assert_last_error(expected_error)
 
@@ -721,11 +723,11 @@ func test_verify_no_interactions_fails():
 	mocked_node.set_process(true) # 1 times
 	mocked_node.set_process(true) # 2 times
 	
-	var expected_error ="""Expecting no more interacions!
-But found interactions on:
-	'set_process(False :bool)'	1 time's
-	'set_process(True :bool)'	2 time's"""
-	expected_error = GdScriptParser.to_unix_format(expected_error)
+	var expected_error ="""
+		Expecting no more interactions!
+		But found interactions on:
+			'set_process(False :bool)'	1 time's
+			'set_process(True :bool)'	2 time's""".dedent().trim_prefix("\n")
 	# it should fail because we have interactions 
 	verify_no_interactions(mocked_node, GdUnitAssert.EXPECT_FAIL)\
 		.has_failure_message(expected_error)
@@ -769,12 +771,12 @@ func test_verify_no_more_interactions_but_has():
 	
 	# now use 'verify_no_more_interactions' to check we have no more interactions on this mock
 	# but should fail with a collecion of all not validated interactions
-	var expected_error ="""Expecting no more interacions!
-But found interactions on:
-	'is_inside_tree()'	2 time's
-	'find_node(mask :String, True :bool, True :bool)'	1 time's
-	'find_node(mask :String, False :bool, False :bool)'	1 time's"""
-	expected_error = GdScriptParser.to_unix_format(expected_error)
+	var expected_error ="""
+		Expecting no more interactions!
+		But found interactions on:
+			'is_inside_tree()'	2 time's
+			'find_node(mask :String, True :bool, True :bool)'	1 time's
+			'find_node(mask :String, False :bool, False :bool)'	1 time's""".dedent().trim_prefix("\n")
 	verify_no_more_interactions(mocked_node, GdUnitAssert.EXPECT_FAIL)\
 		.has_failure_message(expected_error)
 

--- a/addons/gdUnit3/test/mocker/resources/scenes/TestScene.gd
+++ b/addons/gdUnit3/test/mocker/resources/scenes/TestScene.gd
@@ -11,8 +11,13 @@ onready var _box3 = $VBoxContainer/PanelContainer/HBoxContainer/Panel3
 export var _initial_color := Color.red
 
 func _ready():
-	#OS.window_maximized = true
 	connect("panel_color_change", self, "_on_panel_color_changed")
+	# we call this function to verify the _ready is only once called
+	# this is need to verify `add_child` is calling the original implementation only once
+	only_one_time_call()
+
+func only_one_time_call() -> void:
+	pass
 
 #func _notification(what):
 #	prints("TestScene", GdObjects.notification_as_string(what))

--- a/addons/gdUnit3/test/spy/GdUnitSpyBuilderTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyBuilderTest.gd
@@ -55,10 +55,11 @@ func test_double_return_undef_function_with_args() -> void:
 		"	var args :Array = [\"disconnect\"] + [signal_, target_, method_]",
 		"	",
 		"	if __is_verify_interactions():",
-		"		return __verify_interactions(args)",
+		"		__verify_interactions(args)",
+		"		return",
 		"	else:",
 		"		__save_function_interaction(args)",
-		"	return .disconnect(signal_, target_, method_)",
+		"	.disconnect(signal_, target_, method_)",
 		""])
 
 func test_double_void_function_with_args_and_varargs() -> void:
@@ -131,13 +132,14 @@ func test_double_static_script_function_no_args() -> void:
 		"	var args :Array = [\"foo\"] + []",
 		"	",
 		"	if __self[0].__is_verify_interactions():",
-		"		return __self[0].__verify_interactions(args)",
+		"		__self[0].__verify_interactions(args)",
+		"		return",
 		"	else:",
 		"		__self[0].__save_function_interaction(args)",
-		"	return .foo()",
+		"	.foo()",
 		""])
 
-func test_double_static_script_function_with_args() -> void:
+func test_double_static_script_function_with_args_return_void() -> void:
 	var doubler := GdUnitSpyBuilder.SpyFunctionDoubler.new()
 	
 	var fd := GdFunctionDescriptor.new( "foo", 23, false, true, false, TYPE_NIL, "", [
@@ -149,18 +151,53 @@ func test_double_static_script_function_with_args() -> void:
 		"	var args :Array = [\"foo\"] + [arg1, arg2]",
 		"	",
 		"	if __self[0].__is_verify_interactions():",
+		"		__self[0].__verify_interactions(args)",
+		"		return",
+		"	else:",
+		"		__self[0].__save_function_interaction(args)",
+		"	.foo(arg1, arg2)",
+		""])
+
+func test_double_static_script_function_with_args_return_bool() -> void:
+	var doubler := GdUnitSpyBuilder.SpyFunctionDoubler.new()
+	
+	var fd := GdFunctionDescriptor.new( "foo", 23, false, true, false, TYPE_BOOL, "", [
+		GdFunctionArgument.new("arg1", "bool"),
+		GdFunctionArgument.new("arg2", "String", "\"default\"")
+	])
+	assert_array(doubler.double(fd)).contains_exactly([
+		"static func foo(arg1, arg2=\"default\") -> bool:",
+		"	var args :Array = [\"foo\"] + [arg1, arg2]",
+		"	",
+		"	if __self[0].__is_verify_interactions():",
 		"		return __self[0].__verify_interactions(args)",
 		"	else:",
 		"		__self[0].__save_function_interaction(args)",
 		"	return .foo(arg1, arg2)",
 		""])
 
-func test_double_script_function_no_args() -> void:
+func test_double_script_function_no_args_return_void() -> void:
 	var doubler := GdUnitSpyBuilder.SpyFunctionDoubler.new()
 	
 	var fd := GdFunctionDescriptor.new( "foo", 23, false, false, false, TYPE_NIL, "", [])
 	assert_array(doubler.double(fd)).contains_exactly([
 		"func foo():",
+		"	var args :Array = [\"foo\"] + []",
+		"	",
+		"	if __is_verify_interactions():",
+		"		__verify_interactions(args)",
+		"		return",
+		"	else:",
+		"		__save_function_interaction(args)",
+		"	.foo()",
+		""])
+
+func test_double_script_function_no_args_return_bool() -> void:
+	var doubler := GdUnitSpyBuilder.SpyFunctionDoubler.new()
+	
+	var fd := GdFunctionDescriptor.new( "foo", 23, false, false, false, TYPE_BOOL, "", [])
+	assert_array(doubler.double(fd)).contains_exactly([
+		"func foo() -> bool:",
 		"	var args :Array = [\"foo\"] + []",
 		"	",
 		"	if __is_verify_interactions():",
@@ -170,7 +207,7 @@ func test_double_script_function_no_args() -> void:
 		"	return .foo()",
 		""])
 
-func test_double_script_function_with_args() -> void:
+func test_double_script_function_with_args_return_void() -> void:
 	var doubler := GdUnitSpyBuilder.SpyFunctionDoubler.new()
 	
 	var fd := GdFunctionDescriptor.new( "foo", 23, false, false, false, TYPE_NIL, "", [
@@ -179,6 +216,25 @@ func test_double_script_function_with_args() -> void:
 	])
 	assert_array(doubler.double(fd)).contains_exactly([
 		"func foo(arg1, arg2=\"default\"):",
+		"	var args :Array = [\"foo\"] + [arg1, arg2]",
+		"	",
+		"	if __is_verify_interactions():",
+		"		__verify_interactions(args)",
+		"		return",
+		"	else:",
+		"		__save_function_interaction(args)",
+		"	.foo(arg1, arg2)",
+		""])
+
+func test_double_script_function_with_args_return_bool() -> void:
+	var doubler := GdUnitSpyBuilder.SpyFunctionDoubler.new()
+	
+	var fd := GdFunctionDescriptor.new( "foo", 23, false, false, false, TYPE_BOOL, "", [
+		GdFunctionArgument.new("arg1", "bool"),
+		GdFunctionArgument.new("arg2", "String", "\"default\"")
+	])
+	assert_array(doubler.double(fd)).contains_exactly([
+		"func foo(arg1, arg2=\"default\") -> bool:",
 		"	var args :Array = [\"foo\"] + [arg1, arg2]",
 		"	",
 		"	if __is_verify_interactions():",
@@ -198,10 +254,11 @@ func test_double_virtual_script_function_with_arg() -> void:
 		"	var args :Array = [\"_input\"] + [event_]",
 		"	",
 		"	if __is_verify_interactions():",
-		"		return __verify_interactions(args)",
+		"		__verify_interactions(args)",
+		"		return",
 		"	else:",
 		"		__save_function_interaction(args)",
-		"	return ._input(event_)",
+		"	._input(event_)",
 		""])
 
 func test_double_virtual_script_function_without_arg() -> void:
@@ -214,10 +271,11 @@ func test_double_virtual_script_function_without_arg() -> void:
 		"	var args :Array = [\"_ready\"] + []",
 		"	",
 		"	if __is_verify_interactions():",
-		"		return __verify_interactions(args)",
+		"		__verify_interactions(args)",
+		"		return",
 		"	else:",
 		"		__save_function_interaction(args)",
-		"	return ._ready()",
+		"	._ready()",
 		""])
 
 class NodeWithOutVirtualFunc extends Node:

--- a/addons/gdUnit3/test/spy/GdUnitSpyBuilderTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyBuilderTest.gd
@@ -266,17 +266,18 @@ func test_double_virtual_script_function_without_arg() -> void:
 	
 	# void _ready() virtual
 	var fd := get_function_description("Node", "_ready")
-	assert_array(doubler.double(fd)).contains_exactly([
-		"func _ready():",
-		"	var args :Array = [\"_ready\"] + []",
-		"	",
-		"	if __is_verify_interactions():",
-		"		__verify_interactions(args)",
-		"		return",
-		"	else:",
-		"		__save_function_interaction(args)",
-		"	._ready()",
-		""])
+	assert_that(doubler.double(fd).join("\n")).is_equal(
+		"""
+		func _ready() -> void:
+			if __is_verify_interactions():
+				__verify_interactions(["_ready"])
+				return
+			else:
+				__save_function_interaction(["_ready"])
+			# we do not call the original here, because `add_child` does it already
+			# .$(func_name)($(func_arg))
+		""".dedent().trim_prefix("\n"))
+
 
 class NodeWithOutVirtualFunc extends Node:
 	func _ready():

--- a/addons/gdUnit3/test/spy/GdUnitSpyBuilderTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyBuilderTest.gd
@@ -244,7 +244,7 @@ func test_double_script_function_with_args_return_bool() -> void:
 		"	return .foo(arg1, arg2)",
 		""])
 
-func test_double_virtual_script_function_with_arg() -> void:
+func test_double_input_function_do_not_call_super() -> void:
 	var doubler := GdUnitSpyBuilder.SpyFunctionDoubler.new()
 	
 	# void _input(event: InputEvent) virtual
@@ -257,27 +257,22 @@ func test_double_virtual_script_function_with_arg() -> void:
 		"		__verify_interactions(args)",
 		"		return",
 		"	else:",
-		"		__save_function_interaction(args)",
-		"	._input(event_)",
-		""])
+		"		__save_function_interaction(args)"])
 
-func test_double_virtual_script_function_without_arg() -> void:
+func test_double_ready_function_do_not_call_super() -> void:
 	var doubler := GdUnitSpyBuilder.SpyFunctionDoubler.new()
 	
 	# void _ready() virtual
 	var fd := get_function_description("Node", "_ready")
-	assert_that(doubler.double(fd).join("\n")).is_equal(
-		"""
-		func _ready() -> void:
-			if __is_verify_interactions():
-				__verify_interactions(["_ready"])
-				return
-			else:
-				__save_function_interaction(["_ready"])
-			# we do not call the original here, because `add_child` does it already
-			# .$(func_name)($(func_arg))
-		""".dedent().trim_prefix("\n"))
-
+	assert_that(doubler.double(fd)).is_equal([
+		"func _ready():",
+		"	var args :Array = [\"_ready\"] + []",
+		"	",
+		"	if __is_verify_interactions():",
+		"		__verify_interactions(args)",
+		"		return",
+		"	else:",
+		"		__save_function_interaction(args)"])
 
 class NodeWithOutVirtualFunc extends Node:
 	func _ready():

--- a/addons/gdUnit3/test/spy/GdUnitSpyBuilderTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyBuilderTest.gd
@@ -26,9 +26,7 @@ func test_double_return_typed_function_without_arg() -> void:
 		"		return __verify_interactions(args)",
 		"	else:",
 		"		__save_function_interaction(args)",
-		"	if false == false:",
-		"		return .get_class()",
-		"	return \"\"",
+		"	return .get_class()",
 		""])
 
 func test_double_return_typed_function_with_args() -> void:
@@ -44,9 +42,7 @@ func test_double_return_typed_function_with_args() -> void:
 		"		return __verify_interactions(args)",
 		"	else:",
 		"		__save_function_interaction(args)",
-		"	if false == false:",
-		"		return .is_connected(signal_, target_, method_)",
-		"	return false",
+		"	return .is_connected(signal_, target_, method_)",
 		""])
 
 func test_double_return_undef_function_with_args() -> void:
@@ -62,9 +58,7 @@ func test_double_return_undef_function_with_args() -> void:
 		"		return __verify_interactions(args)",
 		"	else:",
 		"		__save_function_interaction(args)",
-		"	if false == false:",
-		"		return .disconnect(signal_, target_, method_)",
-		"	return null",
+		"	return .disconnect(signal_, target_, method_)",
 		""])
 
 func test_double_void_function_with_args_and_varargs() -> void:
@@ -83,19 +77,18 @@ func test_double_void_function_with_args_and_varargs() -> void:
 		"	else:",
 		"		__save_function_interaction(args)",
 		"	",
-		"	if false == false:",
-		"		match varargs.size():",
-		"			0: .emit_signal(signal_)",
-		"			1: .emit_signal(signal_, varargs[0])",
-		"			2: .emit_signal(signal_, varargs[0], varargs[1])",
-		"			3: .emit_signal(signal_, varargs[0], varargs[1], varargs[2])",
-		"			4: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3])",
-		"			5: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4])",
-		"			6: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5])",
-		"			7: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6])",
-		"			8: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7])",
-		"			9: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8])",
-		"			10: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8], varargs[9])",
+		"	match varargs.size():",
+		"		0: .emit_signal(signal_)",
+		"		1: .emit_signal(signal_, varargs[0])",
+		"		2: .emit_signal(signal_, varargs[0], varargs[1])",
+		"		3: .emit_signal(signal_, varargs[0], varargs[1], varargs[2])",
+		"		4: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3])",
+		"		5: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4])",
+		"		6: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5])",
+		"		7: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6])",
+		"		8: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7])",
+		"		9: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8])",
+		"		10: .emit_signal(signal_, varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8], varargs[9])",
 		""])
 
 
@@ -115,19 +108,18 @@ func test_double_void_function_without_args_and_varargs() -> void:
 		"	else:",
 		"		__save_function_interaction(args)",
 		"	",
-		"	if false == false:",
-		"		match varargs.size():",
-		"			0: ._signal_callback()",
-		"			1: ._signal_callback(varargs[0])",
-		"			2: ._signal_callback(varargs[0], varargs[1])",
-		"			3: ._signal_callback(varargs[0], varargs[1], varargs[2])",
-		"			4: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3])",
-		"			5: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4])",
-		"			6: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5])",
-		"			7: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6])",
-		"			8: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7])",
-		"			9: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8])",
-		"			10: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8], varargs[9])",
+		"	match varargs.size():",
+		"		0: ._signal_callback()",
+		"		1: ._signal_callback(varargs[0])",
+		"		2: ._signal_callback(varargs[0], varargs[1])",
+		"		3: ._signal_callback(varargs[0], varargs[1], varargs[2])",
+		"		4: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3])",
+		"		5: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4])",
+		"		6: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5])",
+		"		7: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6])",
+		"		8: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7])",
+		"		9: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8])",
+		"		10: ._signal_callback(varargs[0], varargs[1], varargs[2], varargs[3], varargs[4], varargs[5], varargs[6], varargs[7], varargs[8], varargs[9])",
 		""])
 
 func test_double_static_script_function_no_args() -> void:
@@ -142,9 +134,7 @@ func test_double_static_script_function_no_args() -> void:
 		"		return __self[0].__verify_interactions(args)",
 		"	else:",
 		"		__self[0].__save_function_interaction(args)",
-		"	if false == false:",
-		"		return .foo()",
-		"	return null",
+		"	return .foo()",
 		""])
 
 func test_double_static_script_function_with_args() -> void:
@@ -162,9 +152,7 @@ func test_double_static_script_function_with_args() -> void:
 		"		return __self[0].__verify_interactions(args)",
 		"	else:",
 		"		__self[0].__save_function_interaction(args)",
-		"	if false == false:",
-		"		return .foo(arg1, arg2)",
-		"	return null",
+		"	return .foo(arg1, arg2)",
 		""])
 
 func test_double_script_function_no_args() -> void:
@@ -179,9 +167,7 @@ func test_double_script_function_no_args() -> void:
 		"		return __verify_interactions(args)",
 		"	else:",
 		"		__save_function_interaction(args)",
-		"	if false == false:",
-		"		return .foo()",
-		"	return null",
+		"	return .foo()",
 		""])
 
 func test_double_script_function_with_args() -> void:
@@ -199,9 +185,7 @@ func test_double_script_function_with_args() -> void:
 		"		return __verify_interactions(args)",
 		"	else:",
 		"		__save_function_interaction(args)",
-		"	if false == false:",
-		"		return .foo(arg1, arg2)",
-		"	return null",
+		"	return .foo(arg1, arg2)",
 		""])
 
 func test_double_virtual_script_function_with_arg() -> void:
@@ -217,9 +201,7 @@ func test_double_virtual_script_function_with_arg() -> void:
 		"		return __verify_interactions(args)",
 		"	else:",
 		"		__save_function_interaction(args)",
-		"	if true == false:",
-		"		return ._input(event_)",
-		"	return null",
+		"	return ._input(event_)",
 		""])
 
 func test_double_virtual_script_function_without_arg() -> void:
@@ -235,7 +217,16 @@ func test_double_virtual_script_function_without_arg() -> void:
 		"		return __verify_interactions(args)",
 		"	else:",
 		"		__save_function_interaction(args)",
-		"	if true == false:",
-		"		return ._ready()",
-		"	return null",
+		"	return ._ready()",
 		""])
+
+class NodeWithOutVirtualFunc extends Node:
+	func _ready():
+		pass
+	
+	#func _input(event :InputEvent) -> void:
+
+func test_spy_on_script_respect_virtual_functions():
+	var spy = auto_free(GdUnitSpyBuilder.spy_on_script(auto_free(NodeWithOutVirtualFunc.new()), [], false).new())
+	assert_that(spy.has_method("_ready")).is_true()
+	assert_that(spy.has_method("_input")).is_false()

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -515,15 +515,14 @@ func test_spy_scene_by_path_fail_has_no_script_attached():
 	assert_object(spy_scene).is_null()
 
 func test_spy_scene_initalize():
-	var resource := load("res://addons/gdUnit3/test/mocker/resources/scenes/TestScene.tscn")
-	var instance :Control = auto_free(resource.instance())
-	var spy_scene = spy(instance)
+	var spy_scene = spy("res://addons/gdUnit3/test/mocker/resources/scenes/TestScene.tscn")
 	assert_object(spy_scene).is_not_null()
 	
 	# Add as child to a scene tree to trigger _ready to initalize all variables
 	add_child(spy_scene)
-	# ensure _ready is called after adding to scene tree
-	verify(spy_scene)._ready()
+	# ensure _ready is recoreded and onyl once called
+	verify(spy_scene, 1)._ready()
+	verify(spy_scene, 1).only_one_time_call()
 	assert_object(spy_scene._box1).is_not_null()
 	assert_object(spy_scene._box2).is_not_null()
 	assert_object(spy_scene._box3).is_not_null()

--- a/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit3/test/spy/GdUnitSpyTest.gd
@@ -2,11 +2,15 @@ class_name GdUnitSpyTest
 extends GdUnitTestSuite
 
 # small helper to verify last assert error
-func assert_last_error(expected :String):
+func assert_last_error(expected :String, expected_line_number :int = -1):
+	var last_failure_line_number := GdAssertReports.get_last_error_line_number()
 	var gd_assert := GdUnitAssertImpl.new(self, "")
 	if Engine.has_meta(GdAssertReports.LAST_ERROR):
 		gd_assert._current_error_message = Engine.get_meta(GdAssertReports.LAST_ERROR)
-	gd_assert.has_failure_message(expected)
+	gd_assert.has_failure_message(expected.dedent().trim_prefix("\n"))
+	if expected_line_number != -1:
+		assert_int(last_failure_line_number).is_equal(expected_line_number)
+
 
 func test_cant_spy_is_not_a_instance():
 	# returns null because spy needs an 'real' instance to by spy on
@@ -102,7 +106,7 @@ func test_spy_class_with_custom_formattings() -> void:
 	verify(spy, 1).a1("set_name", "", true)
 	verify_no_more_interactions(spy)
 	verify_no_interactions(spy, GdUnitAssert.EXPECT_FAIL)
-	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(104)
+	assert_int(GdAssertReports.get_last_error_line_number()).is_equal(108)
 
 func test_spy_copied_class_members():
 	var instance = auto_free(load("res://addons/gdUnit3/test/mocker/resources/TestPersion.gd").new("user-x", "street", 56616))
@@ -185,12 +189,12 @@ func test_verify_fail():
 	
 	# verify should fail because we interacts two times and not one
 	verify(spy_node, 1, GdUnitAssert.EXPECT_FAIL).set_process(true)
-	var expected_error := """Expecting interacion on:
-	'set_process(True :bool)'	1 time's
-But found interactions on:
-	'set_process(True :bool)'	2 time's"""
-	expected_error = GdScriptParser.to_unix_format(expected_error)
-	assert_last_error(expected_error)
+	var expected_error := """
+		Expecting interaction on:
+			'set_process(True :bool)'	1 time's
+		But found interactions on:
+			'set_process(True :bool)'	2 time's"""
+	assert_last_error(expected_error, 191)
 
 func test_verify_func_interaction_wiht_PoolStringArray():
 	var spy_instance :ClassWithPoolStringArrayFunc = spy(ClassWithPoolStringArrayFunc.new())
@@ -207,12 +211,12 @@ func test_verify_func_interaction_wiht_PoolStringArray_fail():
 	
 	# try to verify with default array type instead of PoolStringArray type
 	verify(spy_instance, 1, GdUnitAssert.EXPECT_FAIL).set_values([])
-	var expected_error := """Expecting interacion on:
-	'set_values([] :Array)'	1 time's
-But found interactions on:
-	'set_values([] :PoolStringArray)'	1 time's"""
-	expected_error = GdScriptParser.to_unix_format(expected_error)
-	assert_last_error(expected_error)
+	var expected_error := """
+		Expecting interaction on:
+			'set_values([] :Array)'	1 time's
+		But found interactions on:
+			'set_values([] :PoolStringArray)'	1 time's"""
+	assert_last_error(expected_error, 213)
 	
 	reset(spy_instance)
 	# try again with called two times and different args
@@ -220,14 +224,14 @@ But found interactions on:
 	spy_instance.set_values(PoolStringArray(["a", "b"]))
 	spy_instance.set_values([1, 2])
 	verify(spy_instance, 1, GdUnitAssert.EXPECT_FAIL).set_values([])
-	expected_error = """Expecting interacion on:
-	'set_values([] :Array)'	1 time's
-But found interactions on:
-	'set_values([] :PoolStringArray)'	1 time's
-	'set_values([a, b] :PoolStringArray)'	1 time's
-	'set_values([1, 2] :Array)'	1 time's"""
-	expected_error = GdScriptParser.to_unix_format(expected_error)
-	assert_last_error(expected_error)
+	expected_error = """
+		Expecting interaction on:
+			'set_values([] :Array)'	1 time's
+		But found interactions on:
+			'set_values([] :PoolStringArray)'	1 time's
+			'set_values([a, b] :PoolStringArray)'	1 time's
+			'set_values([1, 2] :Array)'	1 time's"""
+	assert_last_error(expected_error, 226)
 
 func test_reset():
 	var instance :Node = auto_free(Node.new())
@@ -262,11 +266,11 @@ func test_verify_no_interactions_fails():
 	spy_node.set_process(true) # 1 times
 	spy_node.set_process(true) # 2 times
 
-	var expected_error ="""Expecting no more interacions!
-But found interactions on:
-	'set_process(False :bool)'	1 time's
-	'set_process(True :bool)'	2 time's"""
-	expected_error = GdScriptParser.to_unix_format(expected_error)
+	var expected_error ="""
+		Expecting no more interactions!
+		But found interactions on:
+			'set_process(False :bool)'	1 time's
+			'set_process(True :bool)'	2 time's""".dedent().trim_prefix("\n")
 	# it should fail because we have interactions
 	verify_no_interactions(spy_node, GdUnitAssert.EXPECT_FAIL)\
 		.has_failure_message(expected_error)
@@ -312,12 +316,12 @@ func test_verify_no_more_interactions_but_has():
 	
 	# now use 'verify_no_more_interactions' to check we have no more interactions on this mock
 	# but should fail with a collecion of all not validated interactions
-	var expected_error ="""Expecting no more interacions!
-But found interactions on:
-	'is_inside_tree()'	2 time's
-	'find_node(mask :String, True :bool, True :bool)'	1 time's
-	'find_node(mask :String, False :bool, False :bool)'	1 time's"""
-	expected_error = GdScriptParser.to_unix_format(expected_error)
+	var expected_error ="""
+		Expecting no more interactions!
+		But found interactions on:
+			'is_inside_tree()'	2 time's
+			'find_node(mask :String, True :bool, True :bool)'	1 time's
+			'find_node(mask :String, False :bool, False :bool)'	1 time's""".dedent().trim_prefix("\n")
 	verify_no_more_interactions(spy_node, GdUnitAssert.EXPECT_FAIL)\
 		.has_failure_message(expected_error)
 
@@ -518,6 +522,8 @@ func test_spy_scene_initalize():
 	
 	# Add as child to a scene tree to trigger _ready to initalize all variables
 	add_child(spy_scene)
+	# ensure _ready is called after adding to scene tree
+	verify(spy_scene)._ready()
 	assert_object(spy_scene._box1).is_not_null()
 	assert_object(spy_scene._box2).is_not_null()
 	assert_object(spy_scene._box3).is_not_null()

--- a/addons/gdUnit3/test/ui/templates/TestSuiteTemplateTest.gd
+++ b/addons/gdUnit3/test/ui/templates/TestSuiteTemplateTest.gd
@@ -11,6 +11,7 @@ func test_show() -> void:
 	var template = spy("res://addons/gdUnit3/src/ui/templates/TestSuiteTemplate.tscn")
 	scene_runner(template)
 	
+	# verify the followup functions are called by _ready()
 	verify(template).setup_editor_colors()
 	verify(template).setup_supported_types()
 	verify(template).load_template(GdUnitTestSuiteTemplate.TEMPLATE_ID_GD)

--- a/addons/gdUnit3/test/ui/templates/TestSuiteTemplateTest.gd
+++ b/addons/gdUnit3/test/ui/templates/TestSuiteTemplateTest.gd
@@ -12,6 +12,7 @@ func test_show() -> void:
 	scene_runner(template)
 	
 	# verify the followup functions are called by _ready()
+	verify(template)._ready()
 	verify(template).setup_editor_colors()
 	verify(template).setup_supported_types()
 	verify(template).load_template(GdUnitTestSuiteTemplate.TEMPLATE_ID_GD)


### PR DESCRIPTION
# Why
During fixing #351 i found out a implemented virtual function was never called. The interaction itself was tracked but to original implementation not called.


# What
- Rework on spy to only double implemented virtual functions
  - do not call super function on _ready and _input because is do by the engine and will result in double function calls
- cleanup spy builder
- fix failure message typo
- better failure report if the value a instance of `InputEvent`
- fix small bug in signal assert
- improve objects deep equal check
- improve readability of spy/mock tests by reformating expected failure messages