### PR TITLE
GD-357: Fix run test in runtime mode

### DIFF
--- a/addons/gdUnit3/src/ui/GdUnitInspector.gd
+++ b/addons/gdUnit3/src/ui/GdUnitInspector.gd
@@ -287,7 +287,11 @@ func _gdUnit_run(debug :bool) -> void:
 		return
 
 	var arguments := Array()
+	if OS.is_stdout_verbose():
+		arguments.append("--verbose")
 	arguments.append("--no-window")
+	arguments.append("--path")
+	arguments.append(ProjectSettings.globalize_path("res://"))
 	#arguments.append("-d")
 	#arguments.append("-s")
 	arguments.append("res://addons/gdUnit3/src/core/GdUnitRunner.tscn")


### PR DESCRIPTION
# Why
On MacOS the `Run Test` was stuck and no execution progress.

# What
Added --path argument to execute the GdUnitRunner scene, it was not need on Windows but needs to be set on MacOS