### PR TITLE
GD-370: Fix spy on function with return type `Varaiant`

### DIFF
--- a/addons/gdUnit3/src/core/GdObjects.gd
+++ b/addons/gdUnit3/src/core/GdObjects.gd
@@ -5,6 +5,11 @@ extends Object
 const TYPE_VOID 	= TYPE_MAX + 1000
 const TYPE_VARARG 	= TYPE_MAX + 1001
 const TYPE_FUNC 	= TYPE_MAX + 1002
+const TYPE_VARIANT	= TYPE_MAX + 1003
+
+# define missing property usage flag
+# https://github.com/godotengine/godot/blob/3.5/core/object.h
+const PROPERTY_USAGE_NIL_IS_VARIANT :int = 1 << 19
 
 # used as default value for varargs
 const TYPE_VARARG_PLACEHOLDER_VALUE = "__null__"
@@ -39,7 +44,8 @@ const TYPE_AS_STRING_MAPPINGS := {
 	TYPE_COLOR_ARRAY: "PoolColorArray",
 	TYPE_VOID: "void",
 	TYPE_VARARG: "VarArg",
-	TYPE_FUNC: "Func"
+	TYPE_FUNC: "Func",
+	TYPE_VARIANT: "Variant"
 }
 
 # holds flipped copy of TYPE_AS_STRING_MAPPINGS initalisized by func 'string_as_typeof'

--- a/addons/gdUnit3/src/core/parse/GdFunctionDescriptor.gd
+++ b/addons/gdUnit3/src/core/parse/GdFunctionDescriptor.gd
@@ -81,6 +81,8 @@ func typeless() -> String:
 	var func_signature := ""
 	if _return_type == TYPE_NIL:
 		func_signature = "func %s(%s):" % [name(), typeless_args()]
+	elif _return_type == GdObjects.TYPE_VARIANT:
+		func_signature = "func %s(%s):" % [name(), typeless_args()]
 	else:
 		func_signature = "func %s(%s) -> %s:" % [name(), typeless_args(), return_type_as_string()]
 	return "static " + func_signature if is_static() else func_signature
@@ -123,11 +125,18 @@ static func extract_from(method_descriptor :Dictionary) -> GdFunctionDescriptor:
 		is_virtual,
 		false,
 		true,
-		method_descriptor["return"]["type"],
+		_extract_return_type(method_descriptor["return"]),
 		method_descriptor["return"]["class_name"],
 		_extract_args(method_descriptor),
 		_build_varargs(is_vararg)
 	)
+
+static func _extract_return_type(return_info :Dictionary) -> int:
+	var type :int = return_info["type"]
+	var usage :int = return_info["usage"]
+	if type == TYPE_NIL and usage & GdObjects.PROPERTY_USAGE_NIL_IS_VARIANT:
+		return GdObjects.TYPE_VARIANT
+	return type
 
 static func _extract_args(method_descriptor :Dictionary) -> Array:
 	var args := Array()

--- a/addons/gdUnit3/test/core/GdObjectsTest.gd
+++ b/addons/gdUnit3/test/core/GdObjectsTest.gd
@@ -531,6 +531,7 @@ func test_all_types() -> void:
 		GdObjects.TYPE_VOID,
 		GdObjects.TYPE_VARARG,
 		GdObjects.TYPE_FUNC,
+		GdObjects.TYPE_VARIANT,
 	])
 
 func test_to_camel_case() -> void:

--- a/addons/gdUnit3/test/core/parse/GdFunctionDescriptorTest.gd
+++ b/addons/gdUnit3/test/core/parse/GdFunctionDescriptorTest.gd
@@ -114,3 +114,19 @@ func test_extract_from_descriptor_is_virtual_func_full_check():
 			_count += 1
 			assert_array(expected_virtual_functions).contains([fd.name()])
 	assert_int(_count).is_equal(expected_virtual_functions.size())
+
+
+func test_extract_from_func_with_return_type_variant():
+	var method_descriptor := get_method_description("Node", "get")
+	var fd := GdFunctionDescriptor.extract_from(method_descriptor)
+	assert_str(fd.name()).is_equal("get")
+	assert_bool(fd.is_virtual()).is_false()
+	assert_bool(fd.is_static()).is_false()
+	assert_bool(fd.is_engine()).is_true()
+	assert_bool(fd.is_vararg()).is_false()
+	assert_int(fd.return_type()).is_equal(GdObjects.TYPE_VARIANT)
+	assert_array(fd.args()).contains_exactly([
+		GdFunctionArgument.new("property_", "String"),
+	])
+	# Variant get(property: String) const
+	assert_str(fd.typeless()).is_equal("func get(property_):")


### PR DESCRIPTION
# Why
Spy on a function with return type `Variant` was wrong doubled and has return always nothing.


# What
- Check the usage flag of the return descriptor and check for `PROPERTY_USAGE_NIL_IS_VARIANT` to determine it is a `Variant`
- Add missing reflection of Variant type
- Add missing flag `PROPERTY_USAGE_NIL_IS_VARIANT`