### PR TITLE
GD-369: Fix failure report coloring on GdUnit console output

### DIFF
--- a/addons/gdUnit3/src/asserts/GdAssertMessages.gd
+++ b/addons/gdUnit3/src/asserts/GdAssertMessages.gd
@@ -426,21 +426,14 @@ static func colorDiff(value :String) -> String:
 	result.append_array(format_chars(additional_chars, ADD_COLOR))
 	return result.get_string_from_ascii()
 
-
 static func format_chars(characters :PoolByteArray, type :Color) -> PoolByteArray:
 	var result := PoolByteArray()
 	if characters.size() == 0:
 		return result
 	if characters.size() == 1 and characters[0] == 10:
-		if type == ADD_COLOR:
-			result.append_array(("[bg color=#%s]\n<--empty line-->[/bg]" % [type.to_html()]).to_utf8())
-		else:
-			result.append_array(("[bg color=#%s][s]\n<--empty line-->[/s][/bg]" % type.to_html()).to_utf8())
+		result.append_array(("[bg color=#%s]<NL>[/bg]" % type.to_html()).to_utf8())
 		return result
-	if type == ADD_COLOR:
-		result.append_array(("[bg color=#%s]%s[/bg]" % [type.to_html(), characters.get_string_from_ascii()]).to_utf8())
-	else:
-		result.append_array(("[bg color=#%s]%s[/bg]" % [type.to_html(), characters.get_string_from_ascii()]).to_utf8())
+	result.append_array(("[bg color=#%s]%s[/bg]" % [type.to_html(), characters.get_string_from_ascii()]).to_utf8())
 	return result
 
 static func humanized(value :String) -> String:

--- a/addons/gdUnit3/src/spy/GdUnitSpyBuilder.gd
+++ b/addons/gdUnit3/src/spy/GdUnitSpyBuilder.gd
@@ -197,14 +197,14 @@ static func spy_on_scene(caller :Object, scene :Node, memory_pool, debug_write) 
 	scene.__set_caller(caller)
 	return GdUnitTools.register_auto_free(scene, memory_pool)
 
-const EXCLUDE_PROPERTIES_TO_COPY = ["script", "type"]
+const EXCLUDE_PROPERTIES_TO_COPY = ["script", "type", "get_global_transform", "rect_global_position"]
 
 static func copy_properties(source :Object, dest :Object) -> void:
 	for property in source.get_property_list():
 		var property_name = property["name"]
-		var property_value = source.get(property_name)
 		if EXCLUDE_PROPERTIES_TO_COPY.has(property_name):
 			continue
+		var property_value = source.get(property_name)
 		#if dest.get(property_name) == null:
 		#	prints("|%s|" % property_name, source.get(property_name))
 		

--- a/addons/gdUnit3/src/ui/GdUnitConsole.gd
+++ b/addons/gdUnit3/src/ui/GdUnitConsole.gd
@@ -68,10 +68,13 @@ func _on_event_test_suite(event :GdUnitEvent):
 			output.newline()
 			output.push_color(Color.lightgreen.to_html())
 			output.append_bbcode("Test Run Summary:")
+			output.pop()
 			output.push_color(_text_color.to_html())
 			output.push_indent(1)
 			output.append_bbcode("| %d total | %d error | %d failed | %d skipped | %d orphans |\n" % [_summary["total_count"], _summary["error_count"], _summary["failed_count"], _summary["skipped_count"], _summary["orphan_nodes"]])
+			output.newline()
 			output.pop_indent(1)
+			output.pop()
 		GdUnitEvent.TESTSUITE_BEFORE:
 			init_statistics(event)
 			output.append_bbcode("Run Test Suite: %s" %  event._suite_name)
@@ -80,50 +83,54 @@ func _on_event_test_suite(event :GdUnitEvent):
 			if event.is_success():
 				output.push_color(Color.lightgreen.to_html())
 				output.append_bbcode("[wave]PASSED[/wave]")
+				output.pop()
 			else:
 				output.push_color(Color.firebrick.to_html())
 				output.append_bbcode("[shake rate=5 level=10][b]FAILED[/b][/shake]")
-			output.pop_indent(1)
+				output.pop()
 			output.append_bbcode(" %+12s" % LocalTime.elapsed(event.elapsed_time()))
 			output.newline()
 			output.push_color(_text_color.to_html())
 			output.push_indent(1)
 			output.append_bbcode("| %d total | %d error | %d failed | %d skipped | %d orphans |\n" % [_statistics["total_count"], _statistics["error_count"], _statistics["failed_count"], _statistics["skipped_count"], _statistics["orphan_nodes"]])
 			output.pop_indent(1)
-			output.pop_indent(1)
+			output.pop()
 			output.newline()
 		GdUnitEvent.TESTCASE_BEFORE:
 			var spaces = "-%d" % (80 - event._suite_name.length())
 			output.push_indent(1)
 			output.append_bbcode(("[color=#" + _engine_type_color.to_html() + "]%s[/color]:[color=#" + _function_color.to_html() + "]%"+spaces+"s[/color]") % [event._suite_name, event._test_name])
-			output.pop_indent(1)
 		GdUnitEvent.TESTCASE_AFTER:
 			var reports := event.reports()
 			update_statistics(event)
-			if not output.text.ends_with("\n"):
-				if event.is_success():
-					output.push_color(Color.lightgreen.to_html())
-					output.append_bbcode("PASSED")
-					output.pop_indent(1)
-					output.append_bbcode(" %+12s" % LocalTime.elapsed(event.elapsed_time()))
-				else:
-					if event.is_skipped():
-						output.push_color(Color.goldenrod.to_html())
-						output.append_bbcode("SKIPPED")
-					if event.is_error() or event.is_failed():
-						output.push_color(Color.firebrick.to_html())
-						output.append_bbcode("FAILED")
-					output.pop_indent(1)
-					output.append_bbcode(" %+12s" % LocalTime.elapsed(event.elapsed_time()))
-					output.newline()
-					output.push_color(_text_color.to_html())
-					var report :GdUnitReport = null if reports.empty() else reports[0]
-					if report:
-						output.push_indent(2)
-						output.append_bbcode("line %d %s" % [report._line_number, report._message])
-						output.pop_indent(2)
-					output.pop_indent(1)
+			if event.is_success():
+				output.push_color(Color.lightgreen.to_html())
+				output.append_bbcode("PASSED")
+				output.pop()
+				output.append_bbcode(" %+12s" % LocalTime.elapsed(event.elapsed_time()))
 				output.newline()
+				output.pop_indent(1)
+			else:
+				if event.is_skipped():
+					output.push_color(Color.goldenrod.to_html())
+					output.append_bbcode("SKIPPED")
+					output.pop()
+				if event.is_error() or event.is_failed():
+					output.push_color(Color.firebrick.to_html())
+					output.append_bbcode("FAILED")
+					output.pop()
+				output.append_bbcode(" %+12s" % LocalTime.elapsed(event.elapsed_time()))
+				output.newline()
+				output.push_color(_text_color.to_html())
+				var report :GdUnitReport = null if reports.empty() else reports[0]
+				if report:
+					output.push_indent(1)
+					output.append_bbcode("line %d %s" % [report._line_number, report._message])
+					output.newline()
+					output.pop_indent(1)
+				output.pop_indent(1)
+				output.pop()
+
 
 func _on_client_connected(client_id :int) -> void:
 	output.clear()

--- a/addons/gdUnit3/src/ui/parts/RichTextEffectBackground.gd
+++ b/addons/gdUnit3/src/ui/parts/RichTextEffectBackground.gd
@@ -1,7 +1,7 @@
 # This effect works currently only with mono fonts
 
 # MIT License
-# Copyright (c) 2020 Mike Schulze
+# Copyright (c) 2023 Mike Schulze
 # https://github.com/MikeSchulze/gdUnit3/blob/master/LICENSE
 
 extends RichTextEffect
@@ -10,106 +10,102 @@ class_name RichTextEffectBackground
 var bbcode = "bg"
 
 var _label: WeakRef
-var _char_size :Vector2
-var _tab_size : int
-var _indent := Dictionary()
-var diff_sub_color := Color(0, 0, 0, 0)
+var _char_size := Vector2(8, 16)
+var _margin := Vector2.ZERO
+var _tab_size :int
+var _diff_sub_color := Color(0, 0, 0, 0)
 var _cache := Dictionary() 
+
+class CharacterInfo:
+	var _position :Vector2
+	var _size :Vector2
+	
+	func _init(position :Vector2, size :Vector2):
+		_position = position
+		_size = size
+
 
 func set_source(label :RichTextLabel) -> void:
 	_label = weakref(label)
 	init_properties()
 
+
 func init_properties() :
 	_cache.clear()
 	# determine character size
-	var char_width := 8
-	var char_height := 16
 	var custom_font = _label.get_ref().get("custom_fonts/mono_font")
 	if custom_font is Font:
-		char_height = custom_font.get_height()
-		char_width = custom_font.get_char_size(23).x
-	_char_size = Vector2(char_width, char_height)
+		_char_size = Vector2(custom_font.get_char_size(23).x, custom_font.get_height())
 	_tab_size = _label.get_ref().tab_size
+	_margin = Vector2(4, 4)
 
-func push_indent(line :int, indent :int) -> void:
-	_indent[line] = indent
-
-func pop_indent(line :int, indent :int) -> void:
-	_indent[line+1] = -indent
-	_cache.clear()
-
-func reset() -> void:
-	_cache.clear()
-	_indent.clear()
-
-func get_text_rect(control :Control) -> Rect2:
-	var style : StyleBox = control.get_stylebox("normal")
-	return Rect2(style.get_offset(), control.get_size() - style.get_minimum_size())
 
 func _process_custom_fx(char_fx: CharFXTransform) -> bool:
 	var label = _label.get_ref() as RichTextLabel
 	var scroll = label.get_v_scroll()
-	var position := get_char_position(char_fx.absolute_index, label.get_text())
-	
-	# padding
-	position += Vector2(4, 4)
+	var char_info :CharacterInfo = get_char_position(char_fx, label.get_text())
+	var position := char_info._position
+	# margin
+	position += _margin
 	# sync with scroll positon
 	position.y -= scroll.value
-	var color = char_fx.env.get("color", diff_sub_color) as Color
+	var color = char_fx.env.get("color", _diff_sub_color) as Color
 	# lower the alpha for better backround
 	color.a = .3
-	label.draw_rect(Rect2(position, _char_size), color)
-	
+	label.draw_rect(Rect2(position, char_info._size), color)
 	# increase the color lightning of the character (for better visualisation on background)
 	char_fx.color = char_fx.color.lightened(.8)
 	return true
+
 
 func _build_char_mapping(text :String) -> Dictionary:
 	_cache.clear()
 	var line_height := get_line_height()
 	var line_index := 0
-	var char_offset := 0
-	var y_offset := 0
-	var last_ident := 0
+	var char_index := 0
 	
-	# replace all tabs, otherwise it will results in invalid background coloring
-	for line in text.replace("\t", "").split("\n"):
+	for line in text.split("\n"):
+		var position = Vector2(0, line_height * line_index)
+		for cp in line.length():
+			var char_size := char_size(line, cp)
+			_cache[char_index] = CharacterInfo.new(position, char_size)
+			#prints( "line:%d:%d" % [line_index, char_index], "'%s' (%d)" % [text[char_index], text.ord_at(char_index)], position, "ident", last_ident)#, "tab:", text[text_index] == "\t", char_size)
+			char_index += 1
+			position.x += char_size.x
 		line_index += 1
-		# build line x_offset by current line indent
-		last_ident = get_line_indent(line_index, last_ident)
-		var x_offset = last_ident * _tab_size
-		
-		for x in line.length():
-			var char_index = char_offset + x
-			_cache[char_index] = Vector2((x_offset + x)*_char_size.x, y_offset)
-		# calculate next line offsets
-		y_offset += line_height
-		char_offset += line.length()
 	return _cache
 
-func get_char_position(char_index :int, text :String ) -> Vector2:
+
+func char_size(line :String, index :int) -> Vector2:
+	var character := line.ord_at(index)
+	match character:
+		9: return Vector2(_tab_size * _char_size.x, _char_size.y)
+		_: return _char_size
+	return _char_size
+
+
+func get_char_position(char_fx: CharFXTransform, text :String ) -> CharacterInfo:
 	if _cache.empty():
 		_build_char_mapping(text)
-	return _cache.get(char_index, Vector2.ONE)
+	return _cache.get(char_fx.absolute_index, CharacterInfo.new(Vector2.ZERO, _char_size))
 
-func get_line_indent(line :int, last_indent := 0) -> int:
-	var line_indent = _indent.get(line, 0)
-	if line_indent == 0:
-		return last_indent
-	if line_indent < 0:
-		return last_indent + line_indent
-	return line_indent
 
 func get_line_height() -> int:
 	var label = _label.get_ref() as RichTextLabel
 	var line_separation = label.get("custom_constants/line_separation")
 	if not line_separation:
 		line_separation = 1
-	return get_char_size().y + line_separation
+	return _char_size.y + line_separation
 
-func get_char_size() -> Vector2:
-	return _char_size
+
+func get_text_rect(control :Control) -> Rect2:
+	var style : StyleBox = control.get_stylebox("normal")
+	return Rect2(style.get_offset(), control.get_size() - style.get_minimum_size())
+
+
+func reset() -> void:
+	_cache.clear()
+
 
 func _notification(what):
 	if what == EditorSettings.NOTIFICATION_EDITOR_SETTINGS_CHANGED:

--- a/addons/gdUnit3/src/ui/parts/RichTextLabelExt.gd
+++ b/addons/gdUnit3/src/ui/parts/RichTextLabelExt.gd
@@ -1,6 +1,6 @@
 # Custom RichTextLabel with custom background colors
 # MIT License
-# Copyright (c) 2020 Mike Schulze
+# Copyright (c) 2023 Mike Schulze
 # https://github.com/MikeSchulze/gdUnit3/blob/master/LICENSE
 
 tool
@@ -30,28 +30,30 @@ func _update_ui_settings():
 
 func set_bbcode(code) -> void:
 	.parse_bbcode(code)
+	_effect.reset()
 	updateMinSize()
 
-func append_bbcode(text :String):
-	# replace all tabs, it results in invalid background coloring
-	var error := .append_bbcode(text.replace("\t", ""))
+func append_bbcode(bbcode :String):
+	# using own ident implementation because the original has issues with ident + leading tabs
+	if _indent != 0:
+		var line = text.split("\n")[-1]
+		if line.length() == 0:
+			for i in _indent:
+				bbcode = bbcode.indent("\t")
+	var error := .append_bbcode(bbcode)
+	_effect.reset()
 	updateMinSize()
 	return error
 
 func push_indent(indent :int) -> void:
-	.push_indent(indent)
 	if _effect:
 		_indent += indent
-		_effect.push_indent(get_line_count(), _indent)
 	if _indent > _max_indent:
 		_max_indent = _indent
 
 func pop_indent(indent :int) -> void:
-	if _indent-indent >= 0:
-		.pop()
-		if _effect:
-			_indent -= indent
-			_effect.pop_indent(get_line_count(), _indent)
+	if _effect:
+		_indent -= indent
 
 # updates the label minmum size by the longest line content
 # to fit the full text to on line, to avoid line wrapping
@@ -70,3 +72,4 @@ func updateMinSize() -> void:
 			rect_min_size = line_size
 	# add extra spacing of 40px for possible scrollbar
 	rect_min_size.x += 40
+


### PR DESCRIPTION
# Why
The failure report has colored diffs but wrong placed

# What
- Fix ident handling on RTL
- rework on background effect for RTL
- fix small error when spy on a node where has no parent

![image](https://user-images.githubusercontent.com/347037/213876647-57f92995-f70d-4bbc-848a-4626f28b7195.png)
