### PR TITLE
GD-390: Use Godot logfile path to scan for test runtime errors

### DIFF
--- a/addons/gdUnit3/src/monitor/GodotGdErrorMonitor.gd
+++ b/addons/gdUnit3/src/monitor/GodotGdErrorMonitor.gd
@@ -7,13 +7,15 @@ var _eof :int
 var _report_enabled := false
 
 func _init().("GodotGdErrorMonitor"):
-	_godot_log_file = GdUnitSettings.get_log_path().get_base_dir() + "/godot.log"
+	_godot_log_file = GdUnitSettings.get_log_path()
 	_report_enabled = is_reporting_enabled()
 
 func start():
 	if _report_enabled:
 		_file = File.new()
-		_file.open(_godot_log_file, File.READ)
+		if _file.open(_godot_log_file, File.READ) != OK:
+			push_error("Can't access Godot logfile '%s', error reporting will be disabled." % _godot_log_file)
+			_report_enabled = false
 		_file.seek_end(0)
 		_eof = _file.get_len()
 		_file.close()

--- a/addons/gdUnit3/test/monitor/GodotGdErrorMonitorTest.gd
+++ b/addons/gdUnit3/test/monitor/GodotGdErrorMonitorTest.gd
@@ -9,13 +9,21 @@ const __source = 'res://addons/gdUnit3/src/monitor/GodotGdErrorMonitor.gd'
 
 
 const error_report = """
-	**ERROR**: Error parsing JSON at line 0: 
-   At: core/bind/core_bind.cpp:3293:parse() - Error parsing JSON at line 0: 
-	"""
+**ERROR**: Error parsing JSON at line 0:
+   At: core/bind/core_bind.cpp:3293:parse() - Error parsing JSON at line 0:
+"""
 const script_error = """
-	**SCRIPT ERROR**: Invalid call. Nonexistent function 'foo' in base 'Reference'.
+**SCRIPT ERROR**: Invalid call. Nonexistent function 'foo' in base 'Reference'.
    At: res://test_test/test_test.gd:14:TestTest.test_with_script_errors() - Invalid call. Nonexistent function 'foo' in base 'Reference'.
-	"""
+"""
+
+
+func _write_log(content :String) -> String:
+	var log_file := create_temp_file("/test_logs/", "test.log")
+	log_file.store_string(content)
+	log_file.flush()
+	return log_file.get_path_absolute()
+
 
 func test_parse_script_error_line_number() -> void:
 	var line := GodotGdErrorMonitor.new()._parse_error_line_number(script_error)
@@ -26,9 +34,10 @@ func test_parse_push_error_line_number() -> void:
 	assert_int(line).is_equal(-1)
 
 func test_scan_for_push_errors() -> void:
+	var log_file := _write_log(error_report)
 	var monitor := mock(GodotGdErrorMonitor, CALL_REAL_FUNC) as GodotGdErrorMonitor
 	monitor._report_enabled = true
-	do_return(error_report).on(monitor)._collect_seek_log()
+	monitor._godot_log_file = log_file
 	
 	# with disabled push_error reporting
 	do_return(false).on(monitor)._is_report_push_errors()
@@ -38,10 +47,8 @@ func test_scan_for_push_errors() -> void:
 	# with enabled push_error reporting
 	do_return(true).on(monitor)._is_report_push_errors()
 	monitor._scan_for_errors()
-	var error =\
-"""	**ERROR**: Error parsing JSON at line 0: 
-   At: core/bind/core_bind.cpp:3293:parse() - Error parsing JSON at line 0: """
-	var expected_report = GdUnitReport.new().create(GdUnitReport.FAILURE, -1, error)
+	var expected_error := error_report.trim_prefix("\n").trim_suffix("\n")
+	var expected_report = GdUnitReport.new().create(GdUnitReport.FAILURE, -1, expected_error)
 	assert_array(monitor.reports()).contains_exactly([expected_report])
 
 func test_scan_for_script_errors() -> void:
@@ -57,8 +64,6 @@ func test_scan_for_script_errors() -> void:
 	# with enabled push_error reporting
 	do_return(true).on(monitor)._is_report_script_errors()
 	monitor._scan_for_errors()
-	var error =\
-"""	**SCRIPT ERROR**: Invalid call. Nonexistent function 'foo' in base 'Reference'.
-   At: res://test_test/test_test.gd:14:TestTest.test_with_script_errors() - Invalid call. Nonexistent function 'foo' in base 'Reference'."""
-	var expected_report = GdUnitReport.new().create(GdUnitReport.FAILURE, 14, error)
+	var expected_error := script_error.trim_prefix("\n").trim_suffix("\n")
+	var expected_report = GdUnitReport.new().create(GdUnitReport.FAILURE, 14, expected_error)
 	assert_array(monitor.reports()).contains_exactly([expected_report])


### PR DESCRIPTION
# Why
Tests never ends when a user changed the path of the Godot log file to another path/name. The `GodotGdErrorMonitor` uses a hardcoded logfile path and did not check if this path exists and ran into an an endless loop when trying to parse the logs.

# What
Now uses the logfile path configured by Godot and added a check if the logfile exists